### PR TITLE
Add Rate Limit provider

### DIFF
--- a/src/main/java/com/auth0/jwk/Bucket.java
+++ b/src/main/java/com/auth0/jwk/Bucket.java
@@ -15,9 +15,10 @@ interface Bucket {
     /**
      * Calculates the wait time before the given amount of tokens will be available in the Bucket.
      *
+     * @param count the amount of tokens to check how much time to wait for.
      * @return the wait time in milliseconds in which the given amount of tokens will be available in the Bucket.
      */
-    long willLeakIn(int count);
+    long willLeakIn(long count);
 
     /**
      * Tries to consume one token from the Bucket.
@@ -29,7 +30,8 @@ interface Bucket {
     /**
      * Tries to consume the given amount of tokens from the Bucket.
      *
+     * @param count the amount of tokens to try to consume.
      * @return true if it could consume the given amount of tokens or false if the Bucket doesn't have that amount of tokens available now.
      */
-    boolean consume(int count);
+    boolean consume(long count);
 }

--- a/src/main/java/com/auth0/jwk/Bucket.java
+++ b/src/main/java/com/auth0/jwk/Bucket.java
@@ -1,0 +1,11 @@
+package com.auth0.jwk;
+
+interface Bucket {
+    long willLeakIn();
+
+    long willLeakIn(int count);
+
+    boolean consume();
+
+    boolean consume(int count);
+}

--- a/src/main/java/com/auth0/jwk/Bucket.java
+++ b/src/main/java/com/auth0/jwk/Bucket.java
@@ -1,11 +1,35 @@
 package com.auth0.jwk;
 
+/**
+ * Token Bucket interface.
+ */
 interface Bucket {
+
+    /**
+     * Calculates the wait time before one token will be available in the Bucket.
+     *
+     * @return the wait time in milliseconds in which one token will be available in the Bucket.
+     */
     long willLeakIn();
 
+    /**
+     * Calculates the wait time before the given amount of tokens will be available in the Bucket.
+     *
+     * @return the wait time in milliseconds in which the given amount of tokens will be available in the Bucket.
+     */
     long willLeakIn(int count);
 
+    /**
+     * Tries to consume one token from the Bucket.
+     *
+     * @return true if it could consume the token or false if the Bucket doesn't have tokens available now.
+     */
     boolean consume();
 
+    /**
+     * Tries to consume the given amount of tokens from the Bucket.
+     *
+     * @return true if it could consume the given amount of tokens or false if the Bucket doesn't have that amount of tokens available now.
+     */
     boolean consume(int count);
 }

--- a/src/main/java/com/auth0/jwk/BucketImpl.java
+++ b/src/main/java/com/auth0/jwk/BucketImpl.java
@@ -1,0 +1,108 @@
+package com.auth0.jwk;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Leaky Bucket implementation to make guarantee availability of a fixed amount of tokens in a given time rate.
+ */
+class BucketImpl implements Bucket {
+
+    private static final int MAX_BUCKET_SIZE = Integer.MAX_VALUE - 5;
+
+    private final int size;
+    private final long rate;
+    private final TimeUnit rateUnit;
+    private final long beginTime = System.currentTimeMillis();
+    private AtomicInteger available;
+    private AtomicLong lastTokenAddedAt;
+
+    public BucketImpl(int size, long rate, TimeUnit rateUnit) {
+        assertPositiveValue(size, MAX_BUCKET_SIZE, "Invalid bucket size.");
+        this.size = size;
+        this.available = new AtomicInteger(size);
+        this.lastTokenAddedAt = new AtomicLong(System.currentTimeMillis());
+        this.rate = rate;
+        this.rateUnit = rateUnit;
+
+        beginRefillAtRate();
+    }
+
+    private void beginRefillAtRate() {
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        Runnable refillTask = new Runnable() {
+            public void run() {
+                try {
+                    rateUnit.sleep(rate);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                addToken();
+            }
+        };
+        executorService.scheduleAtFixedRate(refillTask, rate, rate, rateUnit);
+    }
+
+    private void addToken() {
+        if (available.get() < size) {
+            available.incrementAndGet();
+            log(String.format("Added 1 token.. Current state: %d/%d", available.get(), size));
+        }
+        lastTokenAddedAt.set(System.currentTimeMillis());
+    }
+
+    private void assertPositiveValue(int value, int maxValue, String exceptionMessage) {
+        if (value < 1 || value > maxValue) {
+            throw new IllegalArgumentException(exceptionMessage);
+        }
+    }
+
+    private void log(String message) {
+        long msDiff = System.currentTimeMillis() - beginTime;
+        System.out.println(String.format("%-8d - %s", msDiff, message));
+    }
+
+    @Override
+    public long willLeakIn() {
+        return willLeakIn(1);
+    }
+
+    @Override
+    public long willLeakIn(int count) {
+        assertPositiveValue(count, size, String.format("Cannot consume %d tokens when the BucketImpl size is %d!", count, size));
+        int av = available.get();
+        if (av >= count) {
+            log(String.format("%d Tokens are available already.", count));
+            return 0;
+        }
+
+        long nextIn = rateUnit.toMillis(rate) - System.currentTimeMillis() - lastTokenAddedAt.get();
+        final int remaining = count - av - 1;
+        if (remaining > 0) {
+            nextIn += rateUnit.toMillis(rate) * remaining;
+        }
+        log(String.format("Can't consume %d. Actual state is: %d/%d. Retry in %d ms.", count, available.get(), size, nextIn));
+        return nextIn;
+    }
+
+    @Override
+    public boolean consume() {
+        return consume(1);
+    }
+
+    @Override
+    public boolean consume(int count) {
+        assertPositiveValue(count, size, String.format("Cannot consume %d tokens when the BucketImpl size is %d!", count, size));
+        if (count <= available.get()) {
+            available.addAndGet(-count);
+            log(String.format("Consumed %d tokens.. Current state: %d/%d", count, available.get(), size));
+            return true;
+        }
+        log(String.format("Not enough tokens available to consume %d", count));
+        System.out.println();
+        return false;
+    }
+}

--- a/src/main/java/com/auth0/jwk/BucketImpl.java
+++ b/src/main/java/com/auth0/jwk/BucketImpl.java
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Leaky Bucket implementation to make guarantee availability of a fixed amount of tokens in a given time rate.
+ * Token Bucket implementation to guarantee availability of a fixed amount of tokens in a given time rate.
  */
 class BucketImpl implements Bucket {
 

--- a/src/main/java/com/auth0/jwk/GuavaCachedJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/GuavaCachedJwkProvider.java
@@ -1,5 +1,6 @@
 package com.auth0.jwk;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
@@ -51,5 +52,10 @@ public class GuavaCachedJwkProvider implements JwkProvider {
         } catch (ExecutionException e) {
             throw new SigningKeyNotFoundException("Failed to get key with kid " + keyId, e);
         }
+    }
+
+    @VisibleForTesting
+    JwkProvider getBaseProvider() {
+        return provider;
     }
 }

--- a/src/main/java/com/auth0/jwk/JwkException.java
+++ b/src/main/java/com/auth0/jwk/JwkException.java
@@ -3,6 +3,10 @@ package com.auth0.jwk;
 @SuppressWarnings("WeakerAccess")
 public class JwkException extends Exception {
 
+    public JwkException(String message) {
+        super(message);
+    }
+
     public JwkException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
+++ b/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
@@ -81,7 +81,7 @@ public class JwkProviderBuilder {
      * @param unit unit of time for the expire of jwk
      * @return the builder
      */
-    public JwkProviderBuilder rateLimited(int bucketSize, long refillRate, TimeUnit unit) {
+    public JwkProviderBuilder rateLimited(long bucketSize, long refillRate, TimeUnit unit) {
         bucket = new BucketImpl(bucketSize, refillRate, unit);
         return this;
     }

--- a/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
+++ b/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
@@ -13,15 +13,19 @@ public class JwkProviderBuilder {
     private long expiresIn;
     private long cacheSize;
     private boolean cached;
+    private BucketImpl bucket;
+    private boolean rateLimited;
 
     /**
-     * Creates a new builder
+     * Creates a new builder.
      */
     public JwkProviderBuilder() {
         this.cached = true;
         this.expiresIn = 10;
         this.expiresUnit = TimeUnit.HOURS;
         this.cacheSize = 5;
+        this.rateLimited = true;
+        this.bucket = new BucketImpl(10, 1, TimeUnit.MINUTES);
     }
 
     /**
@@ -36,7 +40,7 @@ public class JwkProviderBuilder {
     }
 
     /**
-     * Toggle the cache of Jwk
+     * Toggle the cache of Jwk. By default the provider will use cache.
      * @param cached if the provider should cache jwks
      * @return the builder
      */
@@ -61,6 +65,28 @@ public class JwkProviderBuilder {
     }
 
     /**
+     * Toggle the rate limit of Jwk. By default the Provider will use rate limit.
+     * @param rateLimited if the provider should rate limit jwks
+     * @return the builder
+     */
+    public JwkProviderBuilder rateLimited(boolean rateLimited) {
+        this.rateLimited = rateLimited;
+        return this;
+    }
+
+    /**
+     * Enable the cache specifying size and expire time.
+     * @param bucketSize max number of jwks to deliver in the given rate.
+     * @param refillRate amount of time to wait before a jwk can the jwk will be cached
+     * @param unit unit of time for the expire of jwk
+     * @return the builder
+     */
+    public JwkProviderBuilder rateLimited(int bucketSize, long refillRate, TimeUnit unit) {
+        bucket = new BucketImpl(bucketSize, refillRate, unit);
+        return this;
+    }
+
+    /**
      * Creates a {@link JwkProvider}
      * @return a newly created {@link JwkProvider}
      */
@@ -68,13 +94,14 @@ public class JwkProviderBuilder {
         if (url == null) {
             throw new IllegalStateException("Cannot build provider without domain");
         }
-
-        final UrlJwkProvider urlProvider = new UrlJwkProvider(url);
-        if (!this.cached) {
-            return urlProvider;
+        JwkProvider urlProvider = new UrlJwkProvider(url);
+        if (this.rateLimited) {
+            urlProvider = new RateLimitedJwkProvider(urlProvider, bucket);
         }
-
-        return new GuavaCachedJwkProvider(urlProvider, cacheSize, expiresIn, expiresUnit);
+        if (this.cached) {
+            urlProvider = new GuavaCachedJwkProvider(urlProvider, cacheSize, expiresIn, expiresUnit);
+        }
+        return urlProvider;
     }
 
     private String normalizeDomain(String domain) {

--- a/src/main/java/com/auth0/jwk/RateLimitReachedException.java
+++ b/src/main/java/com/auth0/jwk/RateLimitReachedException.java
@@ -1,0 +1,21 @@
+package com.auth0.jwk;
+
+@SuppressWarnings("WeakerAccess")
+public class RateLimitReachedException extends JwkException {
+    private final long availableInMs;
+
+    public RateLimitReachedException(long availableInMs) {
+        super(String.format("The Rate Limit has been reached! Please wait %d milliseconds.", availableInMs));
+        this.availableInMs = availableInMs;
+    }
+
+    /**
+     * Returns the delay in which the jwk request can be retried.
+     *
+     * @return the time to wait in milliseconds before retrying the request.
+     */
+    public long getAvailableIn() {
+        return availableInMs;
+    }
+
+}

--- a/src/main/java/com/auth0/jwk/RateLimitedJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/RateLimitedJwkProvider.java
@@ -1,0 +1,37 @@
+package com.auth0.jwk;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Jwk provider that limits the amount of Jwks to deliver in a given rate.
+ */
+@SuppressWarnings("WeakerAccess")
+public class RateLimitedJwkProvider implements JwkProvider {
+
+    private final JwkProvider provider;
+    private final Bucket bucket;
+
+    /**
+     * Creates a new provider that will check the given Bucket if a jwks can be provided now.
+     *
+     * @param bucket   bucket to limit the amount of jwk requested in a given amount of time.
+     * @param provider provider to use to request jwk when the bucket allows it.
+     */
+    public RateLimitedJwkProvider(JwkProvider provider, Bucket bucket) {
+        this.provider = provider;
+        this.bucket = bucket;
+    }
+
+    @Override
+    public Jwk get(final String keyId) throws JwkException {
+        if (!bucket.consume()) {
+            throw new RateLimitReachedException(bucket.willLeakIn());
+        }
+        return provider.get(keyId);
+    }
+
+    @VisibleForTesting
+    JwkProvider getBaseProvider() {
+        return provider;
+    }
+}

--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -37,13 +37,17 @@ public class UrlJwkProvider implements JwkProvider {
      * @param domain domain where to look for the jwks.json file
      */
     public UrlJwkProvider(String domain) {
+        this(urlForDomain(domain));
+    }
+
+    private static URL urlForDomain(String domain) {
         if (Strings.isNullOrEmpty(domain)) {
             throw new IllegalArgumentException("A domain is required");
         }
 
         try {
             final URL url = new URL(domain);
-            this.url = new URL(url, "/.well-known/jwks.json");
+            return new URL(url, "/.well-known/jwks.json");
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Invalid jwks uri", e);
         }

--- a/src/test/java/com/auth0/jwk/BucketImplTest.java
+++ b/src/test/java/com/auth0/jwk/BucketImplTest.java
@@ -13,21 +13,14 @@ public class BucketImplTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private static final long RATE = 500;
-    private static final int SIZE = 5;
+    private static final long RATE = 500L;
+    private static final long SIZE = 5L;
 
     @Test
     public void shouldThrowOnCreateWithNegativeSize() throws Exception {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("Invalid bucket size.");
         new BucketImpl(-1, 10, TimeUnit.SECONDS);
-    }
-
-    @Test
-    public void shouldThrowOnCreateWithMoreThanMaxSize() throws Exception {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Invalid bucket size.");
-        new BucketImpl(Integer.MAX_VALUE, 10, TimeUnit.SECONDS);
     }
 
     @Test

--- a/src/test/java/com/auth0/jwk/BucketImplTest.java
+++ b/src/test/java/com/auth0/jwk/BucketImplTest.java
@@ -60,10 +60,10 @@ public class BucketImplTest {
         assertThat(bucket, notNullValue());
         assertThat(bucket.consume(SIZE), equalTo(true));
 
-        assertThat(bucket.willLeakIn(), lessThan(RATE));
+        assertThat(bucket.willLeakIn(), lessThanOrEqualTo(RATE));
         Thread.sleep(RATE);
         assertThat(bucket.consume(), equalTo(true));
-        assertThat(bucket.willLeakIn(), lessThan(RATE));
+        assertThat(bucket.willLeakIn(), lessThanOrEqualTo(RATE));
     }
 
     @Test

--- a/src/test/java/com/auth0/jwk/BucketImplTest.java
+++ b/src/test/java/com/auth0/jwk/BucketImplTest.java
@@ -1,0 +1,95 @@
+package com.auth0.jwk;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class BucketImplTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private static final long RATE = 500;
+    private static final int SIZE = 5;
+
+    @Test
+    public void shouldThrowOnCreateWithNegativeSize() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Invalid bucket size.");
+        new BucketImpl(-1, 10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shouldThrowOnCreateWithMoreThanMaxSize() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Invalid bucket size.");
+        new BucketImpl(Integer.MAX_VALUE, 10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shouldThrowOnCreateWithNegativeRate() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Invalid bucket refill rate.");
+        new BucketImpl(10, -1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shouldThrowWhenLeakingMoreThanBucketSize() throws Exception {
+        Bucket bucket = new BucketImpl(SIZE, RATE, TimeUnit.SECONDS);
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(String.format("Cannot consume %d tokens when the BucketImpl size is %d!", SIZE + 1, SIZE));
+        bucket.willLeakIn(SIZE + 1);
+    }
+
+    @Test
+    public void shouldThrowWhenConsumingMoreThanBucketSize() throws Exception {
+        Bucket bucket = new BucketImpl(SIZE, RATE, TimeUnit.SECONDS);
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(String.format("Cannot consume %d tokens when the BucketImpl size is %d!", SIZE + 1, SIZE));
+        bucket.consume(SIZE + 1);
+    }
+
+    @Test
+    public void shouldCreateFullBucket() throws Exception {
+        Bucket bucket = new BucketImpl(SIZE, RATE, TimeUnit.MILLISECONDS);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.willLeakIn(SIZE), equalTo(0L));
+        assertThat(bucket.willLeakIn(), equalTo(0L));
+    }
+
+    @Test
+    public void shouldAddOneTokenPerRate() throws Exception {
+        Bucket bucket = new BucketImpl(SIZE, RATE, TimeUnit.MILLISECONDS);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.consume(SIZE), equalTo(true));
+
+        assertThat(bucket.willLeakIn(), lessThan(RATE));
+        Thread.sleep(RATE);
+        assertThat(bucket.consume(), equalTo(true));
+        assertThat(bucket.willLeakIn(), lessThan(RATE));
+    }
+
+    @Test
+    public void shouldConsumeAllBucket() throws Exception {
+        Bucket bucket = new BucketImpl(SIZE, RATE, TimeUnit.MILLISECONDS);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.consume(SIZE), equalTo(true));
+        assertThat(bucket.consume(), equalTo(false));
+    }
+
+    @Test
+    public void shouldConsume() throws Exception {
+        Bucket bucket = new BucketImpl(SIZE, RATE, TimeUnit.MILLISECONDS);
+        assertThat(bucket, notNullValue());
+        assertThat(bucket.consume(), equalTo(true));
+        assertThat(bucket.consume(), equalTo(true));
+        assertThat(bucket.consume(), equalTo(true));
+        assertThat(bucket.consume(), equalTo(true));
+        assertThat(bucket.consume(), equalTo(true));
+        assertThat(bucket.consume(), equalTo(false));
+    }
+}

--- a/src/test/java/com/auth0/jwk/RateLimitReachedExceptionTest.java
+++ b/src/test/java/com/auth0/jwk/RateLimitReachedExceptionTest.java
@@ -1,0 +1,18 @@
+package com.auth0.jwk;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class RateLimitReachedExceptionTest {
+    @Test
+    public void shouldGetAvailableIn() throws Exception {
+        RateLimitReachedException exception = new RateLimitReachedException(123456789);
+        assertThat(exception, notNullValue());
+        assertThat(exception.getMessage(), equalTo("The Rate Limit has been reached! Please wait 123456789 milliseconds."));
+        assertThat(exception.getAvailableIn(), equalTo(123456789L));
+    }
+
+}


### PR DESCRIPTION
Default Rate Limit applied is `10 tokens per minute`. The limit can be disabled by calling `builder.rateLimited(false)`.

```java
new JwkProviderBuilder()
   .rateLimited(false);
   .build();
```

If you need to customize the Rate Limit values, use

```java
long size = 10;
long rate = 30;
TimeUnit unit = TimeUnit.SECONDS;

new JwkProviderBuilder()
   .rateLimited(size, rate, unit);
   .build();
```