### PR TITLE
Refactor JwkProviderBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,26 +50,37 @@ Jwk jwk = provider.get("{kid of the signing key}"); //throws Exception when not 
 JwkProvider http = new UrlJwkProvider("https://samples.auth0.com/");
 JwkProvider provider = new GuavaCachedJwkProvider(http);
 Jwk jwk = provider.get("{kid of the signing key}"); //throws Exception when not found or can't get one
+```
 
+### RateLimitJwkProvider
+
+`RateLimitJwkProvider` will limit the amounts of tokens to get in a given time frame.
+
+> By default the rate is limited to 10 tokens per minute but these values can be changed
+
+```java
+JwkProvider url = new UrlJwkProvider("https://samples.auth0.com/");
+Bucket bucket = new Bucket(10, 1, TimeUnit.MINUTES);
+JwkProvider provider = new RateLimitJwkProvider(url, bucket);
+Jwk jwk = provider.get("{kid of the signing key}"); //throws Exception when not found or can't get one
 ```
 
 ### JwkProviderBuilder
 
-To create a provider for domain `https://samples.auth0.com` with cache.
+To create a provider for domain `https://samples.auth0.com` with cache and rate limit:
 
 ```java
-JwkProvider provider = new JwkProviderBuilder()
-    .forDomain("https://samples.auth0.com/")
+JwkProvider provider = new JwkProviderBuilder("https://samples.auth0.com/")
     .build();
 Jwk jwk = provider.get("{kid of the signing key}"); //throws Exception when not found or can't get one
 ```
 
-and specifying cache attributes
+and specifying cache and rate limit attributes
 
 ```java
-JwkProvider provider = new JwkProviderBuilder()
-    .forDomain("https://samples.auth0.com/")
+JwkProvider provider = new JwkProviderBuilder("https://samples.auth0.com/")
     .cached(10, 24, TimeUnit.HOURS)
+    .rateLimited(10, 1, TimeUnit.MINUTES)
     .build();
 Jwk jwk = provider.get("{kid of the signing key}"); //throws Exception when not found or can't get one
 ```

--- a/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
+++ b/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
 @SuppressWarnings("WeakerAccess")
 public class JwkProviderBuilder {
 
-    private String url;
+    private final String url;
     private TimeUnit expiresUnit;
     private long expiresIn;
     private long cacheSize;
@@ -17,9 +17,16 @@ public class JwkProviderBuilder {
     private boolean rateLimited;
 
     /**
-     * Creates a new builder.
+     * Creates a new Builder with a URL from where to load the jwks.
+     * It can be a url lik 'https://samples.auth0.com' or just the Auth0 domain 'samples.auth0.com'.
+     *
+     * @param domain from where to load the jwks
      */
-    public JwkProviderBuilder() {
+    public JwkProviderBuilder(String domain) {
+        if (domain == null) {
+            throw new IllegalStateException("Cannot build provider without domain");
+        }
+        this.url = normalizeDomain(domain);
         this.cached = true;
         this.expiresIn = 10;
         this.expiresUnit = TimeUnit.HOURS;
@@ -29,18 +36,8 @@ public class JwkProviderBuilder {
     }
 
     /**
-     * Specifies the URL from where to load the jwks. It can be a url lik 'https://samples.auth0.com'
-     * or just the Auth0 domain 'samples.auth0.com'.
-     * @param domain from where to load the jwks
-     * @return the builder
-     */
-    public JwkProviderBuilder forDomain(String domain) {
-        this.url = normalizeDomain(domain);
-        return this;
-    }
-
-    /**
      * Toggle the cache of Jwk. By default the provider will use cache.
+     *
      * @param cached if the provider should cache jwks
      * @return the builder
      */
@@ -51,9 +48,10 @@ public class JwkProviderBuilder {
 
     /**
      * Enable the cache specifying size and expire time.
+     *
      * @param cacheSize number of jwk to cache
      * @param expiresIn amount of time the jwk will be cached
-     * @param unit unit of time for the expire of jwk
+     * @param unit      unit of time for the expire of jwk
      * @return the builder
      */
     public JwkProviderBuilder cached(long cacheSize, long expiresIn, TimeUnit unit) {
@@ -66,6 +64,7 @@ public class JwkProviderBuilder {
 
     /**
      * Toggle the rate limit of Jwk. By default the Provider will use rate limit.
+     *
      * @param rateLimited if the provider should rate limit jwks
      * @return the builder
      */
@@ -76,9 +75,10 @@ public class JwkProviderBuilder {
 
     /**
      * Enable the cache specifying size and expire time.
+     *
      * @param bucketSize max number of jwks to deliver in the given rate.
      * @param refillRate amount of time to wait before a jwk can the jwk will be cached
-     * @param unit unit of time for the expire of jwk
+     * @param unit       unit of time for the expire of jwk
      * @return the builder
      */
     public JwkProviderBuilder rateLimited(long bucketSize, long refillRate, TimeUnit unit) {
@@ -88,12 +88,10 @@ public class JwkProviderBuilder {
 
     /**
      * Creates a {@link JwkProvider}
+     *
      * @return a newly created {@link JwkProvider}
      */
     public JwkProvider build() {
-        if (url == null) {
-            throw new IllegalStateException("Cannot build provider without domain");
-        }
         JwkProvider urlProvider = new UrlJwkProvider(url);
         if (this.rateLimited) {
             urlProvider = new RateLimitedJwkProvider(urlProvider, bucket);

--- a/src/test/java/com/auth0/jwk/JwkProviderBuilderTest.java
+++ b/src/test/java/com/auth0/jwk/JwkProviderBuilderTest.java
@@ -17,31 +17,27 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateForDomain() throws Exception {
-        assertThat(new JwkProviderBuilder().forDomain("samples.auth0.com").build(), notNullValue());
+        assertThat(new JwkProviderBuilder("samples.auth0.com").build(), notNullValue());
     }
 
     @Test
     public void shouldCreateForHttpUrl() throws Exception {
-        assertThat(new JwkProviderBuilder().forDomain("https://samples.auth0.com").build(), notNullValue());
+        assertThat(new JwkProviderBuilder("https://samples.auth0.com").build(), notNullValue());
     }
 
     @Test
     public void shouldFailWhenNoUrlIsProvided() throws Exception {
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Cannot build provider without domain");
-        new JwkProviderBuilder().build();
-    }
-
-    @Test
-    public void shouldFailWhenOnlySpecifyingCache() throws Exception {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Cannot build provider without domain");
-        new JwkProviderBuilder().cached(false).build();
+        new JwkProviderBuilder(null).build();
     }
 
     @Test
     public void shouldCreateCachedProvider() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder().rateLimited(false).cached(true).forDomain("samples.auth0.com").build();
+        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+                .rateLimited(false)
+                .cached(true)
+                .build();
         assertThat(provider, notNullValue());
         assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
         assertThat(((GuavaCachedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
@@ -49,22 +45,21 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateCachedProviderWithCustomValues() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder().rateLimited(false).cached(10, 24, TimeUnit.HOURS).forDomain("samples.auth0.com").build();
+        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+                .rateLimited(false)
+                .cached(10, 24, TimeUnit.HOURS)
+                .build();
         assertThat(provider, notNullValue());
         assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
         assertThat(((GuavaCachedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
     }
 
     @Test
-    public void shouldFailWhenOnlySpecifyingRateLimit() throws Exception {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Cannot build provider without domain");
-        new JwkProviderBuilder().rateLimited(false).build();
-    }
-
-    @Test
     public void shouldCreateRateLimitedProvider() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder().cached(false).rateLimited(true).forDomain("samples.auth0.com").build();
+        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+                .cached(false)
+                .rateLimited(true)
+                .build();
         assertThat(provider, notNullValue());
         assertThat(provider, instanceOf(RateLimitedJwkProvider.class));
         assertThat(((RateLimitedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
@@ -72,7 +67,10 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateRateLimitedProviderWithCustomValues() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder().cached(false).rateLimited(10, 24, TimeUnit.HOURS).forDomain("samples.auth0.com").build();
+        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+                .cached(false)
+                .rateLimited(10, 24, TimeUnit.HOURS)
+                .build();
         assertThat(provider, notNullValue());
         assertThat(provider, instanceOf(RateLimitedJwkProvider.class));
         assertThat(((RateLimitedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
@@ -80,7 +78,10 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateCachedAndRateLimitedProvider() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder().cached(true).rateLimited(true).forDomain("samples.auth0.com").build();
+        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+                .cached(true)
+                .rateLimited(true)
+                .build();
         assertThat(provider, notNullValue());
         assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
         JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
@@ -90,7 +91,10 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateCachedAndRateLimitedProviderWithCustomValues() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder().cached(10, 24, TimeUnit.HOURS).rateLimited(10, 24, TimeUnit.HOURS).forDomain("samples.auth0.com").build();
+        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+                .cached(10, 24, TimeUnit.HOURS)
+                .rateLimited(10, 24, TimeUnit.HOURS)
+                .build();
         assertThat(provider, notNullValue());
         assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
         JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
@@ -100,7 +104,7 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateCachedAndRateLimitedProviderByDefault() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder().forDomain("samples.auth0.com").build();
+        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com").build();
         assertThat(provider, notNullValue());
         assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
         JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();


### PR DESCRIPTION
Because the domain is mandatory, require it at the creation of the Builder's instance.