### PR TITLE
Update UrlJwkProvider.java

### DIFF
--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -47,7 +47,7 @@ public class UrlJwkProvider implements JwkProvider {
 
         try {
             final URL url = new URL(domain);
-            return new URL(url, "/.well-known/jwks.json");
+            return new URL(url);
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Invalid jwks uri", e);
         }


### PR DESCRIPTION
Hi,

Thanks for this awesome library. 

I think the jwks_uri is something which depends on the openid_connect server. So I think it is safe to assume that it is not `https://sso/.well-known/jwks.json` all the time. The better approach would be to just pass the jwks_uri instead of domain.

What do you guys think.

Thanks,
Prithviraj.