### PR TITLE
Removed check on optional alg parameter

### DIFF
--- a/src/main/java/com/auth0/jwk/Jwk.java
+++ b/src/main/java/com/auth0/jwk/Jwk.java
@@ -66,7 +66,7 @@ public class Jwk {
         @SuppressWarnings("unchecked")
         List<String> x5c = (List<String>) values.remove("x5c");
         String x5t = (String) values.remove("x5t");
-        if (kid == null || kty == null || alg == null) {
+        if (kid == null || kty == null) {
             throw new IllegalArgumentException("Attributes " + map + " are not from a valid jwk");
         }
         return new Jwk(kid, kty, alg, use, keyOps, x5u, x5c, x5t, values);


### PR DESCRIPTION
Azure Active Directory JWK does not include the alg parameter. Causing the validation to fail. Since the alg parameter is optional (https://tools.ietf.org/html/rfc7517#page-8) I removed the check in the JWK class.