### PR TITLE
Parse 'key_ops' as an Array rather than a String

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk7
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk7
+- oraclejdk8
 branches:
   only:
     - master

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>com.auth0</groupId>
   <artifactId>jwks-rsa</artifactId>
   <packaging>jar</packaging>
-  <version>0.2.1-SNAPSHOT</version>
+  <version>0.2.2-SNAPSHOT</version>
   <name>jwks-rsa</name>
   <url>http://www.auth0.com</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>com.auth0</groupId>
   <artifactId>jwks-rsa</artifactId>
   <packaging>jar</packaging>
-  <version>0.2.2-SNAPSHOT</version>
+  <version>0.2.1-SNAPSHOT</version>
   <name>jwks-rsa</name>
   <url>http://www.auth0.com</url>
 

--- a/src/main/java/com/auth0/jwk/Jwk.java
+++ b/src/main/java/com/auth0/jwk/Jwk.java
@@ -24,7 +24,7 @@ public class Jwk {
     private final String type;
     private final String algorithm;
     private final String usage;
-    private final String operations;
+    private final List<String> operations;
     private final String certificateUrl;
     private final List<String> certificateChain;
     private final String certificateThumbprint;
@@ -43,7 +43,7 @@ public class Jwk {
      * @param additionalAttributes additional attributes not part of the standard ones
      */
     @SuppressWarnings("WeakerAccess")
-    public Jwk(String id, String type, String algorithm, String usage, String operations, String certificateUrl, List<String> certificateChain, String certificateThumbprint, Map<String, Object> additionalAttributes) {
+    public Jwk(String id, String type, String algorithm, String usage, List<String> operations, String certificateUrl, List<String> certificateChain, String certificateThumbprint, Map<String, Object> additionalAttributes) {
         this.id = id;
         this.type = type;
         this.algorithm = algorithm;
@@ -61,7 +61,8 @@ public class Jwk {
         String kty = (String) values.remove("kty");
         String alg = (String) values.remove("alg");
         String use = (String) values.remove("use");
-        String keyOps = (String) values.remove("key_ops");
+        @SuppressWarnings("unchecked")
+        List<String> keyOps = (List<String>) values.remove("key_ops");
         String x5u = (String) values.remove("x5u");
         @SuppressWarnings("unchecked")
         List<String> x5c = (List<String>) values.remove("x5c");
@@ -93,7 +94,7 @@ public class Jwk {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public String getOperations() {
+    public List<String> getOperations() {
         return operations;
     }
 

--- a/src/main/java/com/auth0/jwk/Jwk.java
+++ b/src/main/java/com/auth0/jwk/Jwk.java
@@ -57,11 +57,6 @@ public class Jwk {
     }
 
     /**
-     * <p>Deprecated: Specification states that 'key_ops' (operations) is expected to contain an array value.
-     * While the operations parameter may currently be accepted as a String,
-     * a future release will limit this to only accept a List
-     * (see {@link #Jwk(String, String, String, String, List, String, List, String, Map)}.</p>
-     *
      * Creates a new Jwk
      * @param id
      * @param type
@@ -73,6 +68,8 @@ public class Jwk {
      * @param certificateThumbprint
      * @param additionalAttributes
      *
+     * @deprecated The specification states that the 'key_ops' (operations) parameter contains an array value.
+     * Use {@link #Jwk(String, String, String, String, List, String, List, String, Map)}
      */
     @Deprecated
     @SuppressWarnings("WeakerAccess")
@@ -122,7 +119,22 @@ public class Jwk {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public List<String> getOperations() {
+    public String getOperations() {
+        if(operations == null || operations.isEmpty()) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        String delimiter = ",";
+        for(String operation : operations) {
+            sb.append(operation);
+            sb.append(delimiter);
+        }
+        String ops = sb.toString();
+        return ops.substring(0, ops.length() - delimiter.length());
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public List<String> getOperationsAsList() {
         return operations;
     }
 

--- a/src/main/java/com/auth0/jwk/Jwk.java
+++ b/src/main/java/com/auth0/jwk/Jwk.java
@@ -10,6 +10,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -55,22 +56,49 @@ public class Jwk {
         this.additionalAttributes = additionalAttributes;
     }
 
+    /**
+     * <p>Deprecated: Specification states that 'key_ops' (operations) is expected to contain an array value.
+     * While the operations parameter may currently be accepted as a String,
+     * a future release will limit this to only accept a List
+     * (see {@link #Jwk(String, String, String, String, List, String, List, String, Map)}.</p>
+     *
+     * Creates a new Jwk
+     * @param id
+     * @param type
+     * @param algorithm
+     * @param usage
+     * @param operations
+     * @param certificateUrl
+     * @param certificateChain
+     * @param certificateThumbprint
+     * @param additionalAttributes
+     *
+     */
+    @Deprecated
+    @SuppressWarnings("WeakerAccess")
+    public Jwk(String id, String type, String algorithm, String usage, String operations, String certificateUrl, List<String> certificateChain, String certificateThumbprint, Map<String, Object> additionalAttributes) {
+        this(id, type, algorithm, usage, Collections.singletonList(operations), certificateUrl, certificateChain, certificateThumbprint, additionalAttributes);
+    }
+
+    @SuppressWarnings("unchecked")
     static Jwk fromValues(Map<String, Object> map) {
         Map<String, Object> values = Maps.newHashMap(map);
         String kid = (String) values.remove("kid");
         String kty = (String) values.remove("kty");
         String alg = (String) values.remove("alg");
         String use = (String) values.remove("use");
-        @SuppressWarnings("unchecked")
-        List<String> keyOps = (List<String>) values.remove("key_ops");
+        Object keyOps = values.remove("key_ops");
         String x5u = (String) values.remove("x5u");
-        @SuppressWarnings("unchecked")
         List<String> x5c = (List<String>) values.remove("x5c");
         String x5t = (String) values.remove("x5t");
         if (kid == null || kty == null || alg == null) {
             throw new IllegalArgumentException("Attributes " + map + " are not from a valid jwk");
         }
-        return new Jwk(kid, kty, alg, use, keyOps, x5u, x5c, x5t, values);
+        if(keyOps instanceof String) {
+            return new Jwk(kid, kty, alg, use, (String) keyOps, x5u, x5c, x5t, values);
+        } else {
+            return new Jwk(kid, kty, alg, use, (List<String>) keyOps, x5u, x5c, x5t, values);
+        }
     }
 
     @SuppressWarnings("WeakerAccess")

--- a/src/test/java/com/auth0/jwk/JwkTest.java
+++ b/src/test/java/com/auth0/jwk/JwkTest.java
@@ -23,7 +23,7 @@ public class JwkTest {
     private static final String MODULUS = "vGChUGMTWZNfRsXxd-BtzC4RDYOMqtIhWHol--HNib5SgudWBg6rEcxvR6LWrx57N6vfo68wwT9_FHlZpaK6NXA_dWFW4f3NftfWLL7Bqy90sO4vijM6LMSE6rnl5VB9_Gsynk7_jyTgYWdTwKur0YRec93eha9oCEXmy7Ob1I2dJ8OQmv2GlvA7XZalMxAq4rFnXLzNQ7hCsHrUJP1p7_7SolWm9vTokkmckzSI_mAH2R27Z56DmI7jUkL9fLU-jz-fz4bkNg-mPz4R-kUmM_ld3-xvto79BtxJvOw5qqtLNnRjiDzoqRv-WrBdw5Vj8Pvrg1fwscfVWHlmq-1pFQ";
     private static final String EXPONENT = "AQAB";
     private static final String CERT_CHAIN = "CERT_CHAIN";
-    private static final List<String> KEY_OPS_ARRAY = Lists.newArrayList("sign");
+    private static final List<String> KEY_OPS_LIST = Lists.newArrayList("sign");
     private static final String KEY_OPS_STRING = "sign";
 
     @Rule
@@ -32,13 +32,14 @@ public class JwkTest {
     @Test
     public void shouldBuildWithMap() throws Exception {
         final String kid = randomKeyId();
-        Map<String, Object> values = publicKeyValues(kid, KEY_OPS_ARRAY);
+        Map<String, Object> values = publicKeyValues(kid, KEY_OPS_LIST);
         Jwk jwk = Jwk.fromValues(values);
 
         assertThat(jwk.getId(), equalTo(kid));
         assertThat(jwk.getAlgorithm(), equalTo(RS_256));
         assertThat(jwk.getType(), equalTo(RSA));
         assertThat(jwk.getUsage(), equalTo(SIG));
+        assertThat(jwk.getOperationsAsList(), equalTo(KEY_OPS_LIST));
         assertThat(jwk.getCertificateThumbprint(), equalTo(THUMBPRINT));
         assertThat(jwk.getCertificateChain(), contains(CERT_CHAIN));
     }
@@ -46,10 +47,12 @@ public class JwkTest {
     @Test
     public void shouldReturnPublicKey() throws Exception {
         final String kid = randomKeyId();
-        Map<String, Object> values = publicKeyValues(kid, KEY_OPS_ARRAY);
+        Map<String, Object> values = publicKeyValues(kid, KEY_OPS_LIST);
         Jwk jwk = Jwk.fromValues(values);
 
         assertThat(jwk.getPublicKey(), notNullValue());
+        assertThat(jwk.getOperationsAsList(), is(KEY_OPS_LIST));
+        assertThat(jwk.getOperations(), is(KEY_OPS_STRING));
     }
 
     @Test
@@ -59,6 +62,31 @@ public class JwkTest {
         Jwk jwk = Jwk.fromValues(values);
 
         assertThat(jwk.getPublicKey(), notNullValue());
+        assertThat(jwk.getOperationsAsList(), is(KEY_OPS_LIST));
+        assertThat(jwk.getOperations(), is(KEY_OPS_STRING));
+    }
+
+    @Test
+    public void shouldReturnPublicKeyForNullKeyOps() throws Exception {
+        final String kid = randomKeyId();
+        Map<String, Object> values = publicKeyValues(kid, null);
+        Jwk jwk = Jwk.fromValues(values);
+
+        assertThat(jwk.getPublicKey(), notNullValue());
+        assertThat(jwk.getOperationsAsList(), nullValue());
+        assertThat(jwk.getOperations(), nullValue());
+    }
+
+    @Test
+    public void shouldReturnPublicKeyForEmptyKeyOps() throws Exception {
+        final String kid = randomKeyId();
+        Map<String, Object> values = publicKeyValues(kid, Lists.newArrayList());
+        Jwk jwk = Jwk.fromValues(values);
+
+        assertThat(jwk.getPublicKey(), notNullValue());
+        assertThat(jwk.getOperationsAsList(), notNullValue());
+        assertThat(jwk.getOperationsAsList().size(), equalTo(0));
+        assertThat(jwk.getOperations(), nullValue());
     }
 
     @Test

--- a/src/test/java/com/auth0/jwk/JwkTest.java
+++ b/src/test/java/com/auth0/jwk/JwkTest.java
@@ -40,6 +40,7 @@ public class JwkTest {
         assertThat(jwk.getType(), equalTo(RSA));
         assertThat(jwk.getUsage(), equalTo(SIG));
         assertThat(jwk.getOperationsAsList(), equalTo(KEY_OPS_LIST));
+        assertThat(jwk.getOperations(), is(KEY_OPS_STRING));
         assertThat(jwk.getCertificateThumbprint(), equalTo(THUMBPRINT));
         assertThat(jwk.getCertificateChain(), contains(CERT_CHAIN));
     }

--- a/src/test/java/com/auth0/jwk/JwkTest.java
+++ b/src/test/java/com/auth0/jwk/JwkTest.java
@@ -7,8 +7,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.net.URL;
 import java.security.SecureRandom;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
@@ -23,6 +23,8 @@ public class JwkTest {
     private static final String MODULUS = "vGChUGMTWZNfRsXxd-BtzC4RDYOMqtIhWHol--HNib5SgudWBg6rEcxvR6LWrx57N6vfo68wwT9_FHlZpaK6NXA_dWFW4f3NftfWLL7Bqy90sO4vijM6LMSE6rnl5VB9_Gsynk7_jyTgYWdTwKur0YRec93eha9oCEXmy7Ob1I2dJ8OQmv2GlvA7XZalMxAq4rFnXLzNQ7hCsHrUJP1p7_7SolWm9vTokkmckzSI_mAH2R27Z56DmI7jUkL9fLU-jz-fz4bkNg-mPz4R-kUmM_ld3-xvto79BtxJvOw5qqtLNnRjiDzoqRv-WrBdw5Vj8Pvrg1fwscfVWHlmq-1pFQ";
     private static final String EXPONENT = "AQAB";
     private static final String CERT_CHAIN = "CERT_CHAIN";
+    private static final List<String> KEY_OPS_ARRAY = Lists.newArrayList("sign");
+    private static final String KEY_OPS_STRING = "sign";
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -30,7 +32,7 @@ public class JwkTest {
     @Test
     public void shouldBuildWithMap() throws Exception {
         final String kid = randomKeyId();
-        Map<String, Object> values = publicKeyValues(kid);
+        Map<String, Object> values = publicKeyValues(kid, KEY_OPS_ARRAY);
         Jwk jwk = Jwk.fromValues(values);
 
         assertThat(jwk.getId(), equalTo(kid));
@@ -44,7 +46,16 @@ public class JwkTest {
     @Test
     public void shouldReturnPublicKey() throws Exception {
         final String kid = randomKeyId();
-        Map<String, Object> values = publicKeyValues(kid);
+        Map<String, Object> values = publicKeyValues(kid, KEY_OPS_ARRAY);
+        Jwk jwk = Jwk.fromValues(values);
+
+        assertThat(jwk.getPublicKey(), notNullValue());
+    }
+
+    @Test
+    public void shouldReturnPublicKeyForStringKeyOps() throws Exception {
+        final String kid = randomKeyId();
+        Map<String, Object> values = publicKeyValues(kid, KEY_OPS_STRING);
         Jwk jwk = Jwk.fromValues(values);
 
         assertThat(jwk.getPublicKey(), notNullValue());
@@ -73,11 +84,12 @@ public class JwkTest {
         return values;
     }
 
-    private static Map<String, Object> publicKeyValues(String kid) {
+    private static Map<String, Object> publicKeyValues(String kid, Object keyOps) {
         Map<String, Object> values = Maps.newHashMap();
         values.put("alg", RS_256);
         values.put("kty", RSA);
         values.put("use", SIG);
+        values.put("key_ops", keyOps);
         values.put("x5c", Lists.newArrayList(CERT_CHAIN));
         values.put("x5t", THUMBPRINT);
         values.put("kid", kid);


### PR DESCRIPTION
Addressing bug where 'key_ops' is parsed as a String rather than a List (expected as an array based on specification: https://tools.ietf.org/html/rfc7517#page-7)