### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk7
+- openjdk7
 branches:
   only:
     - master


### PR DESCRIPTION
`oraclejdk7` is no longer offered by travis-ci. Moving to `openjdk7` instead