### PR TITLE
Issue #20 added url constructor to JwkProviderBuilder

### DIFF
--- a/src/main/java/com/auth0/jwk/JwkUrlFactory.java
+++ b/src/main/java/com/auth0/jwk/JwkUrlFactory.java
@@ -1,0 +1,28 @@
+package com.auth0.jwk;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+class JwkUrlFactory {
+
+    static final String WELL_KNOWN_JWKS_PATH = "/.well-known/jwks.json";
+
+    /**
+     * Builds a URL to jwks.json for the given normalized domain.
+     * @param domain where jwks is published
+     * @return url to jwks
+     */
+    static URL forNormalizedDomain(String domain) {
+        checkArgument(!isNullOrEmpty(domain), "A domain is required");
+
+        try {
+            final URL url = new URL(domain);
+            return new URL(url, WELL_KNOWN_JWKS_PATH);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid jwks uri", e);
+        }
+    }
+}

--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -4,12 +4,10 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -34,23 +32,10 @@ public class UrlJwkProvider implements JwkProvider {
 
     /**
      * Creates a provider that loads from the given domain's well-known directory
-     * @param domain domain where to look for the jwks.json file
+     * @param domain normalized domain where to look for the jwks.json file
      */
     public UrlJwkProvider(String domain) {
-        this(urlForDomain(domain));
-    }
-
-    private static URL urlForDomain(String domain) {
-        if (Strings.isNullOrEmpty(domain)) {
-            throw new IllegalArgumentException("A domain is required");
-        }
-
-        try {
-            final URL url = new URL(domain);
-            return new URL(url, "/.well-known/jwks.json");
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Invalid jwks uri", e);
-        }
+        this(JwkUrlFactory.forNormalizedDomain(domain));
     }
 
     private Map<String, Object> getJwks() throws SigningKeyNotFoundException {

--- a/src/test/java/com/auth0/jwk/JwkProviderBuilderTest.java
+++ b/src/test/java/com/auth0/jwk/JwkProviderBuilderTest.java
@@ -4,10 +4,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.notNullValue;
+import static com.auth0.jwk.JwkUrlFactory.WELL_KNOWN_JWKS_PATH;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class JwkProviderBuilderTest {
@@ -15,26 +16,42 @@ public class JwkProviderBuilderTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    private String domain = "samples.auth0.com";
+    private String normalizedDomain = "https://" + domain;
+
     @Test
-    public void shouldCreateForDomain() throws Exception {
-        assertThat(new JwkProviderBuilder("samples.auth0.com").build(), notNullValue());
+    public void shouldCreateForUrl() throws Exception {
+        URL urlToJwks = new URL(normalizedDomain + WELL_KNOWN_JWKS_PATH);
+        assertThat(new JwkProviderBuilder(urlToJwks).build(), notNullValue());
     }
 
     @Test
-    public void shouldCreateForHttpUrl() throws Exception {
-        assertThat(new JwkProviderBuilder("https://samples.auth0.com").build(), notNullValue());
+    public void shouldCreateForDomain() throws Exception {
+        assertThat(new JwkProviderBuilder(domain).build(), notNullValue());
+    }
+
+    @Test
+    public void shouldCreateForNormalizedDomain() throws Exception {
+        assertThat(new JwkProviderBuilder(normalizedDomain).build(), notNullValue());
     }
 
     @Test
     public void shouldFailWhenNoUrlIsProvided() throws Exception {
         expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Cannot build provider without url to jwks");
+        new JwkProviderBuilder((URL) null).build();
+    }
+
+    @Test
+    public void shouldFailWhenNoDomainIsProvided() throws Exception {
+        expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Cannot build provider without domain");
-        new JwkProviderBuilder(null).build();
+        new JwkProviderBuilder((String) null).build();
     }
 
     @Test
     public void shouldCreateCachedProvider() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+        JwkProvider provider = new JwkProviderBuilder(domain)
                 .rateLimited(false)
                 .cached(true)
                 .build();
@@ -45,7 +62,7 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateCachedProviderWithCustomValues() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+        JwkProvider provider = new JwkProviderBuilder(domain)
                 .rateLimited(false)
                 .cached(10, 24, TimeUnit.HOURS)
                 .build();
@@ -56,7 +73,7 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateRateLimitedProvider() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+        JwkProvider provider = new JwkProviderBuilder(domain)
                 .cached(false)
                 .rateLimited(true)
                 .build();
@@ -67,7 +84,7 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateRateLimitedProviderWithCustomValues() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+        JwkProvider provider = new JwkProviderBuilder(domain)
                 .cached(false)
                 .rateLimited(10, 24, TimeUnit.HOURS)
                 .build();
@@ -78,7 +95,7 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateCachedAndRateLimitedProvider() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+        JwkProvider provider = new JwkProviderBuilder(domain)
                 .cached(true)
                 .rateLimited(true)
                 .build();
@@ -91,7 +108,7 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateCachedAndRateLimitedProviderWithCustomValues() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com")
+        JwkProvider provider = new JwkProviderBuilder(domain)
                 .cached(10, 24, TimeUnit.HOURS)
                 .rateLimited(10, 24, TimeUnit.HOURS)
                 .build();
@@ -104,11 +121,25 @@ public class JwkProviderBuilderTest {
 
     @Test
     public void shouldCreateCachedAndRateLimitedProviderByDefault() throws Exception {
-        JwkProvider provider = new JwkProviderBuilder("samples.auth0.com").build();
+        JwkProvider provider = new JwkProviderBuilder(domain).build();
         assertThat(provider, notNullValue());
         assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
         JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
         assertThat(baseProvider, instanceOf(RateLimitedJwkProvider.class));
         assertThat(((RateLimitedJwkProvider) baseProvider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
+    }
+
+    @Test
+    public void shouldSupportUrlToJwksDomainWithSubPath() throws Exception {
+        String urlToJwksWithSubPath = normalizedDomain + "/sub/path" + WELL_KNOWN_JWKS_PATH;
+        URL url = new URL(urlToJwksWithSubPath);
+        JwkProvider provider = new JwkProviderBuilder(url)
+                .rateLimited(false)
+                .cached(false)
+                .build();
+        assertThat(provider, notNullValue());
+        assertThat(provider, instanceOf(UrlJwkProvider.class));
+        UrlJwkProvider urlJwkProvider = (UrlJwkProvider) provider;
+        assertThat(urlJwkProvider.url.toString(), equalTo(urlToJwksWithSubPath));
     }
 }

--- a/src/test/java/com/auth0/jwk/JwkUrlFactoryTest.java
+++ b/src/test/java/com/auth0/jwk/JwkUrlFactoryTest.java
@@ -1,0 +1,44 @@
+package com.auth0.jwk;
+
+import org.junit.Test;
+
+import static com.auth0.jwk.JwkUrlFactory.WELL_KNOWN_JWKS_PATH;
+import static com.auth0.jwk.JwkUrlFactory.forNormalizedDomain;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class JwkUrlFactoryTest {
+
+    @Test
+    public void shouldNotBeNull() {
+        String domain = "https://samples.auth0.com";
+        assertThat(forNormalizedDomain(domain), notNullValue());
+    }
+
+    @Test
+    public void shouldWorkOnNormalizedDomain() {
+        String domain = "https://samples.auth0.com";
+        assertThat(forNormalizedDomain(domain).toString(), equalTo(domain + WELL_KNOWN_JWKS_PATH));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnNonNormalizedDomain() {
+        String domain = "samples.auth0.com";
+        forNormalizedDomain(domain);
+    }
+
+    @Test
+    public void shouldWorkOnNormalizedDomainWithSlash() {
+        String domain = "https://samples.auth0.com";
+        String domainWithSlash = domain + "/";
+        assertThat(forNormalizedDomain(domainWithSlash).toString(), equalTo(domain + WELL_KNOWN_JWKS_PATH));
+    }
+
+    @Test
+    public void shouldUseOnlyDomain() {
+        String domain = "https://samples.auth0.com";
+        String domainWithSubPath = domain + "/sub/path";
+        assertThat(forNormalizedDomain(domainWithSubPath).toString(), equalTo(domain + WELL_KNOWN_JWKS_PATH));
+    }
+}


### PR DESCRIPTION
- URL constructor added to JwkProviderBuilder, which allows to customize URL's to get JWKS. Before it could only be "<domain>/.well-known/jwks.json", now it can be "<domain>/sub/path/.well-known/jwks.json"
- In case url is null IllegalStateException is thrown, so the behavior is similar to the String constructor
- Unfortunately, I didn't find a way to move JwkProviderBuilder.normalizeDomain to UrlJwkProvider keeping the same behavior
- Slight fixes for JavaDocs
- Please, let me know if more tests required