### PR TITLE
bump commons-io due to security vulnerabilities in that library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <jackson.version>2.8.1</jackson.version>
     <java.version>1.7</java.version>
     <commons.codec.version>1.9</commons.codec.version>
-    <commons.io.version>2.4</commons.io.version>
+    <commons.io.version>2.6</commons.io.version>
     <guava.version>19.0</guava.version>
     <junit.version>4.12</junit.version>
     <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
Hello, this just bumps the commons-IO version. I have a black duck scan that identified two vulnerabilities in this version of IO:

> Apache Commons IO contains a flaw that allows traversing outside of a restricted path. The issue is due to FileNameUtils.normalize not properly sanitizing user input, specifically path traversal style attacks (e.g. '../'). With a specially crafted request, a remote attacker can disclose arbitrary files.

and 

> Apache Commons IO contains a flaw that is due to the program failing to restrict which class can be serialized. This may allow a remote attacker to execute arbitrary Java code via deserialization methods.

The version I bumped it to has no known vulnerabilities (for now)