### PR TITLE
Expose getAll() publicly on UrlJwkProvider

### DIFF
--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -107,7 +107,7 @@ public class UrlJwkProvider implements JwkProvider {
         }
     }
 
-    private List<Jwk> getAll() throws SigningKeyNotFoundException {
+    public List<Jwk> getAll() throws SigningKeyNotFoundException {
         List<Jwk> jwks = Lists.newArrayList();
         @SuppressWarnings("unchecked") final List<Map<String, Object>> keys = (List<Map<String, Object>>) getJwks().get("keys");
 


### PR DESCRIPTION
## Rational
We have a service that has few users but gets updated often.
This leads to problems with the existing Guava cache provider as users experience cache misses on a regular basis when trying to authenticate. As the Guava cache offloads cache loading to the user request, this leads to poor user experience (slow requests).

Exposing the getAll() function publicly on the JWK provider will allow us to build smarter caches that asynchronously poll all JWKs without offloading the work to the user session.
We expect this will improve usability.
