### PR TITLE
Generalized JwkProviderBuilder, adds UrlJwkProviderBuilder

### DIFF
--- a/src/main/java/com/auth0/jwk/UrlJwkProviderBuilder.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProviderBuilder.java
@@ -1,0 +1,58 @@
+package com.auth0.jwk;
+
+import java.net.URL;
+
+import static com.auth0.jwk.UrlJwkProvider.urlForDomain;
+
+public class UrlJwkProviderBuilder extends JwkProviderBuilder {
+
+    /**
+     * Creates a new Builder with the given URL where to load the jwks from.
+     *
+     * @param url to load the jwks
+     * @throws IllegalStateException if url is null
+     * @return the builder
+     */
+    public static UrlJwkProviderBuilder from(URL url) {
+        return new UrlJwkProviderBuilder(url);
+    }
+
+    /**
+     * Creates a new Builder with a domain where to look for the jwks.
+     * <br><br> It can be a url link 'https://samples.auth0.com' or just a domain 'samples.auth0.com'.
+     * If the protocol (http or https) is not provided then https is used by default.
+     * The default jwks path "/.well-known/jwks.json" is appended to the given string domain.
+     * <br><br> For example, when the domain is "samples.auth0.com"
+     * the jwks url that will be used is "https://samples.auth0.com/.well-known/jwks.json"
+     * <br><br> Use {@link #UrlJwkProviderBuilder(URL)} if you need to pass a full URL.
+     * @param domain where jwks is published
+     * @throws IllegalStateException if domain is null
+     * @return the builder
+     * @see UrlJwkProvider#UrlJwkProvider(String)
+     */
+    public static UrlJwkProviderBuilder from(String domain) {
+        return new UrlJwkProviderBuilder(domain);
+    }
+
+    private UrlJwkProviderBuilder(URL url) {
+        super(urlJwkProvider(url));
+    }
+
+    private UrlJwkProviderBuilder(String domain) {
+        this(buildJwksUrl(domain));
+    }
+
+    static URL buildJwksUrl(String domain) {
+        if (domain == null) {
+            throw new IllegalStateException("Cannot build provider without domain");
+        }
+        return urlForDomain(domain);
+    }
+
+    static UrlJwkProvider urlJwkProvider(URL url) {
+        if (url == null) {
+            throw new IllegalStateException("Cannot build provider without url to jwks");
+        }
+        return new UrlJwkProvider(url);
+    }
+}

--- a/src/test/java/com/auth0/jwk/JwkProviderBuilderTest.java
+++ b/src/test/java/com/auth0/jwk/JwkProviderBuilderTest.java
@@ -21,22 +21,120 @@ public class JwkProviderBuilderTest {
     private String domain = "samples.auth0.com";
     private String normalizedDomain = "https://" + domain;
 
+    private JwkProvider customProvider = keyId -> null;
+
+    @Test
+    public void shouldCreateForProvider() {
+        assertThat(JwkProviderBuilder.from(customProvider).build(), notNullValue());
+    }
+
+    @Test
+    public void shouldFailWhenNoCustomProviderIsProvided() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Cannot build provider without custom provider");
+        JwkProviderBuilder.from(null).build();
+    }
+
+    @Test
+    public void shouldCreateCachedProvider() {
+        JwkProvider provider = JwkProviderBuilder.from(customProvider)
+                .rateLimited(false)
+                .cached(true)
+                .build();
+        assertThat(provider, notNullValue());
+        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
+        assertThat(((GuavaCachedJwkProvider) provider).getBaseProvider(), equalTo(customProvider));
+    }
+
+    @Test
+    public void shouldCreateCachedProviderWithCustomValues() {
+        JwkProvider provider = JwkProviderBuilder.from(customProvider)
+                .rateLimited(false)
+                .cached(10, 24, TimeUnit.HOURS)
+                .build();
+        assertThat(provider, notNullValue());
+        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
+        assertThat(((GuavaCachedJwkProvider) provider).getBaseProvider(), equalTo(customProvider));
+    }
+
+    @Test
+    public void shouldCreateRateLimitedProvider() {
+        JwkProvider provider = JwkProviderBuilder.from(customProvider)
+                .cached(false)
+                .rateLimited(true)
+                .build();
+        assertThat(provider, notNullValue());
+        assertThat(provider, instanceOf(RateLimitedJwkProvider.class));
+        assertThat(((RateLimitedJwkProvider) provider).getBaseProvider(), equalTo(customProvider));
+    }
+
+    @Test
+    public void shouldCreateRateLimitedProviderWithCustomValues() {
+        JwkProvider provider = JwkProviderBuilder.from(customProvider)
+                .cached(false)
+                .rateLimited(10, 24, TimeUnit.HOURS)
+                .build();
+        assertThat(provider, notNullValue());
+        assertThat(provider, instanceOf(RateLimitedJwkProvider.class));
+        assertThat(((RateLimitedJwkProvider) provider).getBaseProvider(), equalTo(customProvider));
+    }
+
+    @Test
+    public void shouldCreateCachedAndRateLimitedProvider() {
+        JwkProvider provider = JwkProviderBuilder.from(customProvider)
+                .cached(true)
+                .rateLimited(true)
+                .build();
+        assertThat(provider, notNullValue());
+        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
+        JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
+        assertThat(baseProvider, instanceOf(RateLimitedJwkProvider.class));
+        assertThat(((RateLimitedJwkProvider) baseProvider).getBaseProvider(), equalTo(customProvider));
+    }
+
+    @Test
+    public void shouldCreateCachedAndRateLimitedProviderWithCustomValues() {
+        JwkProvider provider = JwkProviderBuilder.from(customProvider)
+                .cached(10, 24, TimeUnit.HOURS)
+                .rateLimited(10, 24, TimeUnit.HOURS)
+                .build();
+        assertThat(provider, notNullValue());
+        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
+        JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
+        assertThat(baseProvider, instanceOf(RateLimitedJwkProvider.class));
+        assertThat(((RateLimitedJwkProvider) baseProvider).getBaseProvider(), equalTo(customProvider));
+    }
+
+    @Test
+    public void shouldCreateCachedAndRateLimitedProviderByDefault() {
+        JwkProvider provider = JwkProviderBuilder.from(customProvider).build();
+        assertThat(provider, notNullValue());
+        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
+        JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
+        assertThat(baseProvider, instanceOf(RateLimitedJwkProvider.class));
+        assertThat(((RateLimitedJwkProvider) baseProvider).getBaseProvider(), equalTo(customProvider));
+    }
+
+    @Deprecated
     @Test
     public void shouldCreateForUrl() throws Exception {
         URL urlToJwks = new URL(normalizedDomain + WELL_KNOWN_JWKS_PATH);
         assertThat(new JwkProviderBuilder(urlToJwks).build(), notNullValue());
     }
 
+    @Deprecated
     @Test
     public void shouldCreateForDomain() {
         assertThat(new JwkProviderBuilder(domain).build(), notNullValue());
     }
 
+    @Deprecated
     @Test
     public void shouldCreateForNormalizedDomain() {
         assertThat(new JwkProviderBuilder(normalizedDomain).build(), notNullValue());
     }
 
+    @Deprecated
     @Test
     public void shouldFailWhenNoUrlIsProvided() {
         expectedException.expect(IllegalStateException.class);
@@ -44,6 +142,7 @@ public class JwkProviderBuilderTest {
         new JwkProviderBuilder((URL) null).build();
     }
 
+    @Deprecated
     @Test
     public void shouldFailWhenNoDomainIsProvided() {
         expectedException.expect(IllegalStateException.class);
@@ -51,86 +150,7 @@ public class JwkProviderBuilderTest {
         new JwkProviderBuilder((String) null).build();
     }
 
-    @Test
-    public void shouldCreateCachedProvider() {
-        JwkProvider provider = new JwkProviderBuilder(domain)
-                .rateLimited(false)
-                .cached(true)
-                .build();
-        assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
-        assertThat(((GuavaCachedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
-    }
-
-    @Test
-    public void shouldCreateCachedProviderWithCustomValues() {
-        JwkProvider provider = new JwkProviderBuilder(domain)
-                .rateLimited(false)
-                .cached(10, 24, TimeUnit.HOURS)
-                .build();
-        assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
-        assertThat(((GuavaCachedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
-    }
-
-    @Test
-    public void shouldCreateRateLimitedProvider() {
-        JwkProvider provider = new JwkProviderBuilder(domain)
-                .cached(false)
-                .rateLimited(true)
-                .build();
-        assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(RateLimitedJwkProvider.class));
-        assertThat(((RateLimitedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
-    }
-
-    @Test
-    public void shouldCreateRateLimitedProviderWithCustomValues() {
-        JwkProvider provider = new JwkProviderBuilder(domain)
-                .cached(false)
-                .rateLimited(10, 24, TimeUnit.HOURS)
-                .build();
-        assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(RateLimitedJwkProvider.class));
-        assertThat(((RateLimitedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
-    }
-
-    @Test
-    public void shouldCreateCachedAndRateLimitedProvider() {
-        JwkProvider provider = new JwkProviderBuilder(domain)
-                .cached(true)
-                .rateLimited(true)
-                .build();
-        assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
-        JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
-        assertThat(baseProvider, instanceOf(RateLimitedJwkProvider.class));
-        assertThat(((RateLimitedJwkProvider) baseProvider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
-    }
-
-    @Test
-    public void shouldCreateCachedAndRateLimitedProviderWithCustomValues() {
-        JwkProvider provider = new JwkProviderBuilder(domain)
-                .cached(10, 24, TimeUnit.HOURS)
-                .rateLimited(10, 24, TimeUnit.HOURS)
-                .build();
-        assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
-        JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
-        assertThat(baseProvider, instanceOf(RateLimitedJwkProvider.class));
-        assertThat(((RateLimitedJwkProvider) baseProvider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
-    }
-
-    @Test
-    public void shouldCreateCachedAndRateLimitedProviderByDefault() {
-        JwkProvider provider = new JwkProviderBuilder(domain).build();
-        assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
-        JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
-        assertThat(baseProvider, instanceOf(RateLimitedJwkProvider.class));
-        assertThat(((RateLimitedJwkProvider) baseProvider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
-    }
-
+    @Deprecated
     @Test
     public void shouldSupportUrlToJwksDomainWithSubPath() throws Exception {
         String urlToJwksWithSubPath = normalizedDomain + "/sub/path" + WELL_KNOWN_JWKS_PATH;
@@ -144,4 +164,5 @@ public class JwkProviderBuilderTest {
         UrlJwkProvider urlJwkProvider = (UrlJwkProvider) provider;
         assertThat(urlJwkProvider.url.toString(), equalTo(urlToJwksWithSubPath));
     }
+
 }

--- a/src/test/java/com/auth0/jwk/UrlJwkProviderBuilderTest.java
+++ b/src/test/java/com/auth0/jwk/UrlJwkProviderBuilderTest.java
@@ -1,0 +1,68 @@
+package com.auth0.jwk;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.net.URL;
+
+import static com.auth0.jwk.UrlJwkProvider.WELL_KNOWN_JWKS_PATH;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class UrlJwkProviderBuilderTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private String domain = "samples.auth0.com";
+    private String normalizedDomain = "https://" + domain;
+
+    @Test
+    public void shouldCreateForUrl() throws Exception {
+        URL urlToJwks = new URL(normalizedDomain + WELL_KNOWN_JWKS_PATH);
+        assertThat(UrlJwkProviderBuilder.from(urlToJwks).build(), notNullValue());
+    }
+
+    @Test
+    public void shouldCreateForDomain() {
+        assertThat(UrlJwkProviderBuilder.from(domain).build(), notNullValue());
+    }
+
+    @Test
+    public void shouldCreateForNormalizedDomain() {
+        assertThat(UrlJwkProviderBuilder.from(normalizedDomain).build(), notNullValue());
+    }
+
+    @Test
+    public void shouldFailWhenNoUrlIsProvided() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Cannot build provider without url to jwks");
+        UrlJwkProviderBuilder.from((URL) null).build();
+    }
+
+    @Test
+    public void shouldFailWhenNoDomainIsProvided() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Cannot build provider without domain");
+        UrlJwkProviderBuilder.from((String) null).build();
+    }
+
+
+    @Test
+    public void shouldSupportUrlToJwksDomainWithSubPath() throws Exception {
+        String urlToJwksWithSubPath = normalizedDomain + "/sub/path" + WELL_KNOWN_JWKS_PATH;
+        URL url = new URL(urlToJwksWithSubPath);
+        JwkProvider provider = UrlJwkProviderBuilder.from(url)
+                .rateLimited(false)
+                .cached(false)
+                .build();
+        assertThat(provider, notNullValue());
+        assertThat(provider, instanceOf(UrlJwkProvider.class));
+        UrlJwkProvider urlJwkProvider = (UrlJwkProvider) provider;
+        assertThat(urlJwkProvider.url.toString(), equalTo(urlToJwksWithSubPath));
+    }
+
+}


### PR DESCRIPTION
- Support for builder a rate-limited/cached provider using any provider as the base instead of only `UrlJwkProvider`
- `JwkProviderBuilder` generalized, old URL/domain constructors deprecated in favor of `UrkJwkProviderBuilder`