### PR TITLE
Update guava to version 27.0.1-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation group: 'commons-codec', name: 'commons-codec', version:'1.11'
     implementation group: 'commons-io', name: 'commons-io', version:'2.6'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.9.8'
-    implementation group: 'com.google.guava', name: 'guava', version:'27.0.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version:'27.1-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.12'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation group: 'commons-codec', name: 'commons-codec', version:'1.11'
     implementation group: 'commons-io', name: 'commons-io', version:'2.6'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.9.8'
-    implementation group: 'com.google.guava', name: 'guava', version:'27.0-jre'
+    implementation group: 'com.google.guava', name: 'guava', version:'27.0.1-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.12'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'


### PR DESCRIPTION
There is a problem in com.google.guava:guava:27.0-jre - jar contains duplicate classes from com.google.guava:failureaccess:1.0 on which it also depends:
https://github.com/google/guava/issues/3302

Since this library depends on Google Guava, using it as dependency causes my build to fail:

```
[WARNING] Found duplicate (but equal) classes in [com.google.guava:failureaccess:1.0,com.google.guava:guava:27.0-jre] :
[WARNING]   com.google.common.util.concurrent.internal.InternalFutureFailureAccess
[WARNING]   com.google.common.util.concurrent.internal.InternalFutures
```

The problem was fixed in guava 27.0.1 (please see https://github.com/google/guava/releases/tag/v27.0.1) hence the version update.