### PR TITLE
Add content-type header to the jwks request

### DIFF
--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -96,6 +96,7 @@ public class UrlJwkProvider implements JwkProvider {
             if (readTimeout != null) {
                 c.setReadTimeout(readTimeout);
             }
+            c.setRequestProperty("Accept", "application/json");
             final InputStream inputStream = c.getInputStream();
             final JsonFactory factory = new JsonFactory();
             final JsonParser parser = factory.createParser(inputStream);

--- a/src/test/java/com/auth0/jwk/UrlJwkProviderTest.java
+++ b/src/test/java/com/auth0/jwk/UrlJwkProviderTest.java
@@ -198,7 +198,7 @@ public class UrlJwkProviderTest {
     }
 
     @Test
-    public void shouldConfigureURLConnectionTimeouts() throws Exception {
+    public void shouldConfigureURLConnection() throws Exception {
         URLConnection urlConnection = mock(URLConnection.class);
 
         // Although somewhat of a hack, this approach gets the job done - this method can 
@@ -213,6 +213,7 @@ public class UrlJwkProviderTest {
         Jwk jwk = urlJwkProvider.get("NkJCQzIyQzRBMEU4NjhGNUU4MzU4RkY0M0ZDQzkwOUQ0Q0VGNUMwQg");
         assertNotNull(jwk);
 
+        //Request Timeout assertions
         ArgumentCaptor<Integer> connectTimeoutCaptor = ArgumentCaptor.forClass(Integer.class);
         verify(urlConnection).setConnectTimeout(connectTimeoutCaptor.capture());
         assertThat(connectTimeoutCaptor.getValue(), is(connectTimeout));
@@ -220,5 +221,8 @@ public class UrlJwkProviderTest {
         ArgumentCaptor<Integer> readTimeoutCaptor = ArgumentCaptor.forClass(Integer.class);
         verify(urlConnection).setReadTimeout(readTimeoutCaptor.capture());
         assertThat(readTimeoutCaptor.getValue(), is(readTimeout));
+
+        //Request Headers assertions
+        verify(urlConnection).setRequestProperty("Accept", "application/json");
     }
 }


### PR DESCRIPTION
### Changes

Explicitly sets the content-type expectation in the request header.

### References

Will close https://github.com/auth0/jwks-rsa-java/issues/57

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
