### PR TITLE
Concatenate JWKS path with existing path on domain if present

### DIFF
--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -1,8 +1,5 @@
 package com.auth0.jwk;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.annotations.VisibleForTesting;
@@ -10,7 +7,11 @@ import com.google.common.collect.Lists;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.*;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
 import java.util.List;
 import java.util.Map;
 
@@ -64,8 +65,12 @@ public class UrlJwkProvider implements JwkProvider {
      * <br><br> It can be a url link 'https://samples.auth0.com' or just a domain 'samples.auth0.com'.
      * If the protocol (http or https) is not provided then https is used by default.
      * The default jwks path "/.well-known/jwks.json" is appended to the given string domain.
+     * If the domain url contains a path, e.g. 'https://auth.example.com/some-resource', the path is preserved and the
+     * default jwks path is appended.
      * <br><br> For example, when the domain is "samples.auth0.com"
      * the jwks url that will be used is "https://samples.auth0.com/.well-known/jwks.json"
+     * If the domain string is "https://auth.example.com/some-resource", the jwks url that will be used is
+     * "https://auth.example.com/some-resource/.well-known/jwks.json"
      * <br><br> Use {@link #UrlJwkProvider(URL)} if you need to pass a full URL.
      *
      * @param domain where jwks is published

--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -9,9 +9,7 @@ import com.google.common.collect.Lists;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
+import java.net.*;
 import java.util.List;
 import java.util.Map;
 
@@ -80,9 +78,9 @@ public class UrlJwkProvider implements JwkProvider {
         }
 
         try {
-            final URL url = new URL(domain);
-            return new URL(url, WELL_KNOWN_JWKS_PATH);
-        } catch (MalformedURLException e) {
+            final URI uri = new URI(domain + WELL_KNOWN_JWKS_PATH).normalize();
+            return uri.toURL();
+        } catch (MalformedURLException | URISyntaxException e) {
             throw new IllegalArgumentException("Invalid jwks uri", e);
         }
     }

--- a/src/test/java/com/auth0/jwk/UrlJwkProviderTest.java
+++ b/src/test/java/com/auth0/jwk/UrlJwkProviderTest.java
@@ -147,11 +147,35 @@ public class UrlJwkProviderTest {
     }
 
     @Test
-    public void shouldUseOnlyDomain() {
+    public void shouldUseDomainAndPathWithSlashIfPresent() {
         String domain = "samples.auth0.com";
         String domainWithSubPath = domain + "/sub/path/";
         String actualJwksUrl = new UrlJwkProvider(domainWithSubPath).url.toString();
-        assertThat(actualJwksUrl, equalTo("https://" + domain + WELL_KNOWN_JWKS_PATH));
+        assertThat(actualJwksUrl, equalTo("https://" + domain + "/sub/path" + WELL_KNOWN_JWKS_PATH));
+    }
+
+    @Test
+    public void shouldUseDomainAndPathWithoutSlashIfPresent() {
+        String domain = "samples.auth0.com";
+        String domainWithSubPath = domain + "/sub/path";
+        String actualJwksUrl = new UrlJwkProvider(domainWithSubPath).url.toString();
+        assertThat(actualJwksUrl, equalTo("https://" + domain + "/sub/path" + WELL_KNOWN_JWKS_PATH));
+    }
+
+    @Test
+    public void shouldUseDomainAndSinglePathWithSlashIfPresent() {
+        String domain = "samples.auth0.com";
+        String domainWithSubPath = domain + "/path/";
+        String actualJwksUrl = new UrlJwkProvider(domainWithSubPath).url.toString();
+        assertThat(actualJwksUrl, equalTo("https://" + domain + "/path" + WELL_KNOWN_JWKS_PATH));
+    }
+
+    @Test
+    public void shouldUseDomainAndSinglePathWithoutSlashIfPresent() {
+        String domain = "samples.auth0.com";
+        String domainWithSubPath = domain + "/path";
+        String actualJwksUrl = new UrlJwkProvider(domainWithSubPath).url.toString();
+        assertThat(actualJwksUrl, equalTo("https://" + domain + "/path" + WELL_KNOWN_JWKS_PATH));
     }
 
     @Test

--- a/src/test/java/com/auth0/jwk/UrlJwkProviderTest.java
+++ b/src/test/java/com/auth0/jwk/UrlJwkProviderTest.java
@@ -8,7 +8,11 @@ import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.net.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
 
 import static com.auth0.jwk.UrlJwkProvider.WELL_KNOWN_JWKS_PATH;
 import static org.hamcrest.Matchers.*;


### PR DESCRIPTION
In the current jwks url provider implementation any path on domain will be replaced by the "well known" jwks path. This will likely work for most providers, but some (e.g. AWS Cognito) uses a unique resource path on a shared endpoint to identify the issuer ie. `https://cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_example`

I'm aware this might have been a deliberate decision given that there is a unit test to verify this behavior. However, I think allowing for a more flexible approach will benefit this library since it's being actively used in other projects such as [ktor](https://ktor.io/servers/features/authentication/jwt.html)

### Changes

- Directly concatenate the domain string with the JWKS path and use URI.normalize() to ensure correct behavior regardless of trailing slash is present or not.
- Added/changed unit tests to reflect new behavior

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing 

- [X] This change adds test coverage
- [X] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
