### PR TITLE
Improve ObjectMapper use

### DIFF
--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 
@@ -31,6 +32,7 @@ public class UrlJwkProvider implements JwkProvider {
     private final Integer connectTimeout;
     private final Integer readTimeout;
 
+    private final ObjectReader reader;
     /**
      * Creates a provider that loads from the given URL
      *
@@ -55,6 +57,8 @@ public class UrlJwkProvider implements JwkProvider {
         this.url = url;
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
+        
+        this.reader = new ObjectMapper().readerFor(Map.class);
     }
 
     /**
@@ -97,12 +101,10 @@ public class UrlJwkProvider implements JwkProvider {
                 c.setReadTimeout(readTimeout);
             }
             c.setRequestProperty("Accept", "application/json");
-            final InputStream inputStream = c.getInputStream();
-            final JsonFactory factory = new JsonFactory();
-            final JsonParser parser = factory.createParser(inputStream);
-            final TypeReference<Map<String, Object>> typeReference = new TypeReference<Map<String, Object>>() {
-            };
-            return new ObjectMapper().reader().readValue(parser, typeReference);
+            
+            try (InputStream inputStream = c.getInputStream()) {
+                return reader.readValue(inputStream);
+            }
         } catch (IOException e) {
             throw new SigningKeyNotFoundException("Cannot obtain jwks from url " + url.toString(), e);
         }


### PR DESCRIPTION
### Changes

Avoid creating new instances of ObjectMapper for each request; reuse the thread-safe ObjectReader instead.

### References

This approach is using

https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/deser/std/MapDeserializer.java

for deserializer. Consider the code

```
import com.fasterxml.jackson.databind.ObjectMapper;

import java.io.IOException;
import java.util.Map;

public class JacksonMapExample1 {

    public static void main(String[] args) {

        ObjectMapper mapper = new ObjectMapper();
        String json = "{\"name\":\"mkyong\", \"age\":37}";

        try {

            // convert JSON string to Map
            Map<String, Object> map = mapper.readValue(json, Map.class);

            //Map<String, Object> map = mapper.readValue(json, new TypeReference<Map<String, Object>>() {});

            System.out.println(map);

            System.out.println(map.get("age").getClass());
        } catch (IOException e) {
            e.printStackTrace();
        }

    }
}
```

for comparing new / old approach.
### Testing

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
