### PR TITLE
Update jackson-databind to address CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ test {
 dependencies {
     implementation group: 'commons-codec', name: 'commons-codec', version:'1.13'
     implementation group: 'commons-io', name: 'commons-io', version:'2.6'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.9.9.3'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.10.0.pr3'
     implementation group: 'com.google.guava', name: 'guava', version:'27.1-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.12'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'


### PR DESCRIPTION
### Changes

Update `jackson-databind` dependency to 2.10.0.pr3 to address CVE.

### References

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14540

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
