### PR TITLE
Adding a getPrivateKey method to Jwk Class

### DIFF
--- a/src/main/java/com/auth0/jwk/InvalidPrivateKeyException.java
+++ b/src/main/java/com/auth0/jwk/InvalidPrivateKeyException.java
@@ -1,0 +1,9 @@
+package com.auth0.jwk;
+
+@SuppressWarnings("WeakerAccess")
+public class InvalidPrivateKeyException extends JwkException {
+
+    public InvalidPrivateKeyException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/com/auth0/jwk/Jwk.java
+++ b/src/main/java/com/auth0/jwk/Jwk.java
@@ -206,7 +206,7 @@ public class Jwk {
             BigInteger crtCoefficient = new BigInteger(1, Base64.decodeBase64("qi"));
             return kf.generatePrivate(new RSAPrivateCrtKeySpec(modulus, publicExponent, privateExponent, primeP, primeQ, primeExponentP, primeExponentQ, crtCoefficient));
         } catch (InvalidKeySpecException e) {
-            throw new InvalidPrivateKeyException("Invalid public key", e);
+            throw new InvalidPrivateKeyException("Invalid private key", e);
         } catch (NoSuchAlgorithmException e) {
             throw new InvalidPrivateKeyException("Invalid algorithm to generate key", e);
         }

--- a/src/test/java/com/auth0/jwk/JwkTest.java
+++ b/src/test/java/com/auth0/jwk/JwkTest.java
@@ -22,6 +22,12 @@ public class JwkTest {
     private static final String THUMBPRINT = "THUMBPRINT";
     private static final String MODULUS = "vGChUGMTWZNfRsXxd-BtzC4RDYOMqtIhWHol--HNib5SgudWBg6rEcxvR6LWrx57N6vfo68wwT9_FHlZpaK6NXA_dWFW4f3NftfWLL7Bqy90sO4vijM6LMSE6rnl5VB9_Gsynk7_jyTgYWdTwKur0YRec93eha9oCEXmy7Ob1I2dJ8OQmv2GlvA7XZalMxAq4rFnXLzNQ7hCsHrUJP1p7_7SolWm9vTokkmckzSI_mAH2R27Z56DmI7jUkL9fLU-jz-fz4bkNg-mPz4R-kUmM_ld3-xvto79BtxJvOw5qqtLNnRjiDzoqRv-WrBdw5Vj8Pvrg1fwscfVWHlmq-1pFQ";
     private static final String EXPONENT = "AQAB";
+    private static final String PRIVATEEXPONENT = "X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q";
+    private static final String PRIMEP = "83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs";
+    private static final String PRIMEQ = "3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelxk";
+    private static final String PRIMEEXPONENTP = "G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0";
+    private static final String PRIMEEXPONENTQ = "s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk";
+    private static final String CRTCOEFFICENT = "GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU";
     private static final String CERT_CHAIN = "CERT_CHAIN";
     private static final List<String> KEY_OPS_LIST = Lists.newArrayList("sign");
     private static final String KEY_OPS_STRING = "sign";
@@ -32,7 +38,7 @@ public class JwkTest {
     @Test
     public void shouldBuildWithMap() throws Exception {
         final String kid = randomKeyId();
-        Map<String, Object> values = publicKeyValues(kid, KEY_OPS_LIST);
+        Map<String, Object> values = privateKeyValues(kid, KEY_OPS_LIST);
         Jwk jwk = Jwk.fromValues(values);
 
         assertThat(jwk.getId(), equalTo(kid));
@@ -44,7 +50,7 @@ public class JwkTest {
         assertThat(jwk.getCertificateThumbprint(), equalTo(THUMBPRINT));
         assertThat(jwk.getCertificateChain(), contains(CERT_CHAIN));
     }
-
+    
     @Test
     public void shouldReturnPublicKey() throws Exception {
         final String kid = randomKeyId();
@@ -52,6 +58,17 @@ public class JwkTest {
         Jwk jwk = Jwk.fromValues(values);
 
         assertThat(jwk.getPublicKey(), notNullValue());
+        assertThat(jwk.getOperationsAsList(), is(KEY_OPS_LIST));
+        assertThat(jwk.getOperations(), is(KEY_OPS_STRING));
+    }
+
+    @Test
+    public void shouldReturnPrivateKey() throws Exception {
+        final String kid = randomKeyId();
+        Map<String, Object> values = privateKeyValues(kid, KEY_OPS_LIST);
+        Jwk jwk = Jwk.fromValues(values);
+
+        assertThat(jwk.getPrivateKey(), notNullValue());
         assertThat(jwk.getOperationsAsList(), is(KEY_OPS_LIST));
         assertThat(jwk.getOperations(), is(KEY_OPS_STRING));
     }
@@ -68,6 +85,17 @@ public class JwkTest {
     }
 
     @Test
+    public void shouldReturnPrivateKeyForStringKeyOpsParam() throws Exception {
+        final String kid = randomKeyId();
+        Map<String, Object> values = privateKeyValues(kid, KEY_OPS_STRING);
+        Jwk jwk = Jwk.fromValues(values);
+
+        assertThat(jwk.getPrivateKey(), notNullValue());
+        assertThat(jwk.getOperationsAsList(), is(KEY_OPS_LIST));
+        assertThat(jwk.getOperations(), is(KEY_OPS_STRING));
+    }
+
+    @Test
     public void shouldReturnPublicKeyForNullKeyOpsParam() throws Exception {
         final String kid = randomKeyId();
         Map<String, Object> values = publicKeyValues(kid, null);
@@ -79,12 +107,35 @@ public class JwkTest {
     }
 
     @Test
+    public void shouldReturnPrivateKeyForNullKeyOpsParam() throws Exception {
+        final String kid = randomKeyId();
+        Map<String, Object> values = privateKeyValues(kid, null);
+        Jwk jwk = Jwk.fromValues(values);
+
+        assertThat(jwk.getPrivateKey(), notNullValue());
+        assertThat(jwk.getOperationsAsList(), nullValue());
+        assertThat(jwk.getOperations(), nullValue());
+    }
+
+    @Test
     public void shouldReturnPublicKeyForEmptyKeyOpsParam() throws Exception {
         final String kid = randomKeyId();
         Map<String, Object> values = publicKeyValues(kid, Lists.newArrayList());
         Jwk jwk = Jwk.fromValues(values);
 
         assertThat(jwk.getPublicKey(), notNullValue());
+        assertThat(jwk.getOperationsAsList(), notNullValue());
+        assertThat(jwk.getOperationsAsList().size(), equalTo(0));
+        assertThat(jwk.getOperations(), nullValue());
+    }
+
+    @Test
+    public void shouldReturnPrivateKeyForEmptyKeyOpsParam() throws Exception {
+        final String kid = randomKeyId();
+        Map<String, Object> values = privateKeyValues(kid, Lists.newArrayList());
+        Jwk jwk = Jwk.fromValues(values);
+
+        assertThat(jwk.getPrivateKey(), notNullValue());
         assertThat(jwk.getOperationsAsList(), notNullValue());
         assertThat(jwk.getOperationsAsList().size(), equalTo(0));
         assertThat(jwk.getOperations(), nullValue());
@@ -105,8 +156,11 @@ public class JwkTest {
         //kid is optional - https://tools.ietf.org/html/rfc7517#section-4.5
         final String kid = randomKeyId();
         Map<String, Object> values = publicKeyValues(kid, KEY_OPS_LIST);
+        Map<String, Object> privateValues = privateKeyValues(kid, KEY_OPS_LIST);
         values.remove("kid");
+        privateValues.remove("kid");
         Jwk.fromValues(values);
+        Jwk.fromValues(privateValues);
     }
 
     @Test
@@ -153,6 +207,26 @@ public class JwkTest {
         values.put("kid", kid);
         values.put("n", MODULUS);
         values.put("e", EXPONENT);
+        return values;
+    }
+
+    private static Map<String, Object> privateKeyValues(String kid, Object keyOps) {
+        Map<String, Object> values = Maps.newHashMap();
+        values.put("alg", RS_256);
+        values.put("kty", RSA);
+        values.put("use", SIG);
+        values.put("key_ops", keyOps);
+        values.put("x5c", Lists.newArrayList(CERT_CHAIN));
+        values.put("x5t", THUMBPRINT);
+        values.put("kid", kid);
+        values.put("n", MODULUS);
+        values.put("e", EXPONENT);
+        values.put("d",PRIVATEEXPONENT);
+        values.put("p",PRIMEP);
+        values.put("q",PRIMEQ);
+        values.put("dp",PRIMEEXPONENTP);
+        values.put("dq",PRIMEEXPONENTQ);
+        values.put("qi",CRTCOEFFICENT);
         return values;
     }
 }


### PR DESCRIPTION
### Changes
[Issue#53](https://github.com/auth0/jwks-rsa-java/issues/53)

Please describe both what is changing and why this is important. Include:

- getPrivateKey method added to Jwk class.
- Added InvalidPrivateKeyException to be throw when there is error with generating PrivateKey.

### References

[Issue#53](https://github.com/auth0/jwks-rsa-java/issues/53)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
