### PR TITLE
Add JwkSet

### DIFF
--- a/src/main/java/com/auth0/jwk/JwkSet.java
+++ b/src/main/java/com/auth0/jwk/JwkSet.java
@@ -1,0 +1,78 @@
+package com.auth0.jwk;
+
+import java.util.Collections;
+import java.util.List;
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Represents a set of JSON Web Keys (JWK) used to verify the signature of JWTs.
+ */
+public class JwkSet {
+
+    private final List<Jwk> keys;
+
+    /**
+     * Create a new empty JWK set.
+     */
+    public JwkSet() {
+        this(Collections.<Jwk>emptyList());
+    }
+
+    /**
+     * Creates a new JWK set with a single key.
+     * @param key the JWK. Must not be {@code null}.
+     */
+    public JwkSet(final Jwk key) {
+        this(Collections.singletonList(key));
+        checkArgument(key != null, "The JWK must not be null");
+    }
+
+    /**
+     * Creates a new JWK set with a list of keys.
+     * @param keys the list of keys. Must not be {@code null}.
+     */
+    public JwkSet(final List<Jwk> keys) {
+        checkArgument(keys != null, "The JWK list must not be null");
+        this.keys = Collections.unmodifiableList(keys);
+    }
+
+    /**
+     * Get the keys of this JWK set.
+     * @return The keys, or an empty list if there are no keys.
+     */
+    public List<Jwk> getKeys() {
+        return keys;
+    }
+
+    /**
+     * Get the key in this JWK set matching the key ID.
+     * @param keyId The key ID (kid) of the JWK to get.
+     * @return The JWK or {@code null} if no JWK is found.
+     */
+    public Jwk getKey(String keyId) {
+        for (Jwk key : keys) {
+            if (key.getId() != null && key.getId().equals(keyId)) {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the key in this JWK set matching the key ID. If the key ID is null and there is only one JWK in this set,
+     * that JWK will be returned.
+     *
+     * <p>This method enables backwards compatibility that allows the only JWK to be returned if the specified keyId is
+     * {@code null}</p>
+     *
+     * @param keyId The key ID (kid) of the JWK to get. If {@code null} and the set contains one Jwk, that JWK will be returned.
+     * @return The JWK or {@code null} if the set contains no JWKs.
+     */
+    Jwk getKeyByIdOrSingleEntry(String keyId) {
+        if (keyId == null && keys.size() == 1) {
+            return keys.get(0);
+        }
+
+        return getKey(keyId);
+    }
+}

--- a/src/main/java/com/auth0/jwk/JwkSet.java
+++ b/src/main/java/com/auth0/jwk/JwkSet.java
@@ -7,31 +7,22 @@ import static com.google.common.base.Preconditions.checkArgument;
 /**
  * Represents a set of JSON Web Keys (JWK) used to verify the signature of JWTs.
  */
-public class JwkSet {
+class JwkSet {
 
     private final List<Jwk> keys;
 
     /**
      * Create a new empty JWK set.
      */
-    public JwkSet() {
+    JwkSet() {
         this(Collections.<Jwk>emptyList());
-    }
-
-    /**
-     * Creates a new JWK set with a single key.
-     * @param key the JWK. Must not be {@code null}.
-     */
-    public JwkSet(final Jwk key) {
-        this(Collections.singletonList(key));
-        checkArgument(key != null, "The JWK must not be null");
     }
 
     /**
      * Creates a new JWK set with a list of keys.
      * @param keys the list of keys. Must not be {@code null}.
      */
-    public JwkSet(final List<Jwk> keys) {
+    JwkSet(final List<Jwk> keys) {
         checkArgument(keys != null, "The JWK list must not be null");
         this.keys = Collections.unmodifiableList(keys);
     }
@@ -40,39 +31,26 @@ public class JwkSet {
      * Get the keys of this JWK set.
      * @return The keys, or an empty list if there are no keys.
      */
-    public List<Jwk> getKeys() {
+    List<Jwk> getKeys() {
         return keys;
     }
 
     /**
-     * Get the key in this JWK set matching the key ID.
+     * Get the key in this JWK set matching the key ID. If the key ID is null and there is only one JWK in this set,
+     * that JWK will be returned.
      * @param keyId The key ID (kid) of the JWK to get.
      * @return The JWK or {@code null} if no JWK is found.
      */
-    public Jwk getKey(String keyId) {
+    Jwk getKey(String keyId) {
+        if (keyId == null && keys.size() == 1) {
+            return keys.get(0);
+        }
+
         for (Jwk key : keys) {
             if (key.getId() != null && key.getId().equals(keyId)) {
                 return key;
             }
         }
         return null;
-    }
-
-    /**
-     * Get the key in this JWK set matching the key ID. If the key ID is null and there is only one JWK in this set,
-     * that JWK will be returned.
-     *
-     * <p>This method enables backwards compatibility that allows the only JWK to be returned if the specified keyId is
-     * {@code null}</p>
-     *
-     * @param keyId The key ID (kid) of the JWK to get. If {@code null} and the set contains one Jwk, that JWK will be returned.
-     * @return The JWK or {@code null} if the set contains no JWKs.
-     */
-    Jwk getKeyByIdOrSingleEntry(String keyId) {
-        if (keyId == null && keys.size() == 1) {
-            return keys.get(0);
-        }
-
-        return getKey(keyId);
     }
 }

--- a/src/test/java/com/auth0/jwk/JwkSetTest.java
+++ b/src/test/java/com/auth0/jwk/JwkSetTest.java
@@ -1,0 +1,91 @@
+package com.auth0.jwk;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class JwkSetTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void shouldThrowWhenCreatedWithNullKey() {
+        expectedException.expect(IllegalArgumentException.class);
+        new JwkSet((Jwk)null);
+    }
+
+    @Test
+    public void shouldThrowWhenCreatedWithNullList() {
+        expectedException.expect(IllegalArgumentException.class);
+        new JwkSet((List<Jwk>)null);
+    }
+
+    @Test
+    public void shouldFindKeyWithId() {
+        Jwk jwk1 = getJwk("KID");
+        Jwk jwk2 = getJwk("KID2");
+
+        JwkSet jwkSet = new JwkSet(Arrays.asList(jwk1, jwk2));
+        assertThat(jwkSet.getKeys().size(), is(2));
+        assertThat(jwkSet.getKey("KID"), equalTo(jwk1));
+        assertThat(jwkSet.getKey("KID2"), equalTo(jwk2));
+        assertThat(jwkSet.getKey("NOPE"), nullValue());
+    }
+
+    @Test
+    public void shouldReturnNullIfSetIsEmpty() {
+        JwkSet jwkSet = new JwkSet();
+
+        assertThat(jwkSet.getKey("KID"), nullValue());
+        assertThat(jwkSet.getKeys(), emptyCollectionOf(Jwk.class));
+    }
+
+    @Test
+    public void shouldReturnNullIfKeyIdIsNull() {
+        Jwk jwk = getJwk(null);
+        JwkSet jwkSet = new JwkSet(Collections.singletonList(jwk));
+
+        assertThat(jwkSet.getKey(null), nullValue());
+    }
+
+    @Test
+    public void shouldReturnSingleKeyWhenKidIsNullAndSetContainsSingleKey() {
+        Jwk jwk = getJwk("KID");
+        JwkSet jwkSet = new JwkSet(jwk);
+
+        Jwk foundKey = jwkSet.getKeyByIdOrSingleEntry(null);
+        assertThat(foundKey, equalTo(jwk));
+    }
+
+    @Test
+    public void shouldReturnNullWhenKidIsNullAndSetIsEmpty() {
+        JwkSet jwkSet = new JwkSet();
+
+        Jwk foundKey = jwkSet.getKeyByIdOrSingleEntry(null);
+        assertThat(foundKey, nullValue());
+    }
+
+    @Test
+    public void shouldReturnNullWhenKidIsNullAndSetHasMultipleKeys() {
+        Jwk jwk1 = getJwk("KID");
+        Jwk jwk2 = getJwk("KID2");
+
+        JwkSet jwkSet = new JwkSet(Arrays.asList(jwk1, jwk2));
+
+        Jwk foundKey = jwkSet.getKeyByIdOrSingleEntry(null);
+        assertThat(foundKey, nullValue());
+    }
+
+    private Jwk getJwk(String kid) {
+        return new Jwk(kid, "type", "alg", "usage", Collections.<String>emptyList(), "certUrl",
+                Collections.<String>emptyList(), "certThumbprint", Collections.<String, Object>emptyMap());
+    }
+}

--- a/src/test/java/com/auth0/jwk/JwkSetTest.java
+++ b/src/test/java/com/auth0/jwk/JwkSetTest.java
@@ -6,7 +6,6 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -17,21 +16,15 @@ public class JwkSetTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Test
-    public void shouldThrowWhenCreatedWithNullKey() {
-        expectedException.expect(IllegalArgumentException.class);
-        new JwkSet((Jwk)null);
-    }
-
-    @Test
     public void shouldThrowWhenCreatedWithNullList() {
         expectedException.expect(IllegalArgumentException.class);
-        new JwkSet((List<Jwk>)null);
+        new JwkSet(null);
     }
 
     @Test
     public void shouldFindKeyWithId() {
-        Jwk jwk1 = getJwk("KID");
-        Jwk jwk2 = getJwk("KID2");
+        Jwk jwk1 = getMockJwk("KID");
+        Jwk jwk2 = getMockJwk("KID2");
 
         JwkSet jwkSet = new JwkSet(Arrays.asList(jwk1, jwk2));
         assertThat(jwkSet.getKeys().size(), is(2));
@@ -50,18 +43,19 @@ public class JwkSetTest {
 
     @Test
     public void shouldReturnNullIfKeyIdIsNull() {
-        Jwk jwk = getJwk(null);
-        JwkSet jwkSet = new JwkSet(Collections.singletonList(jwk));
+        Jwk jwk1 = getMockJwk(null);
+        Jwk jwk2 = getMockJwk("KID");
 
+        JwkSet jwkSet = new JwkSet(Arrays.asList(jwk1, jwk2));
         assertThat(jwkSet.getKey(null), nullValue());
     }
 
     @Test
     public void shouldReturnSingleKeyWhenKidIsNullAndSetContainsSingleKey() {
-        Jwk jwk = getJwk("KID");
-        JwkSet jwkSet = new JwkSet(jwk);
+        Jwk jwk = getMockJwk("KID");
+        JwkSet jwkSet = new JwkSet(Collections.singletonList(jwk));
 
-        Jwk foundKey = jwkSet.getKeyByIdOrSingleEntry(null);
+        Jwk foundKey = jwkSet.getKey(null);
         assertThat(foundKey, equalTo(jwk));
     }
 
@@ -69,22 +63,22 @@ public class JwkSetTest {
     public void shouldReturnNullWhenKidIsNullAndSetIsEmpty() {
         JwkSet jwkSet = new JwkSet();
 
-        Jwk foundKey = jwkSet.getKeyByIdOrSingleEntry(null);
+        Jwk foundKey = jwkSet.getKey(null);
         assertThat(foundKey, nullValue());
     }
 
     @Test
     public void shouldReturnNullWhenKidIsNullAndSetHasMultipleKeys() {
-        Jwk jwk1 = getJwk("KID");
-        Jwk jwk2 = getJwk("KID2");
+        Jwk jwk1 = getMockJwk("KID");
+        Jwk jwk2 = getMockJwk("KID2");
 
         JwkSet jwkSet = new JwkSet(Arrays.asList(jwk1, jwk2));
 
-        Jwk foundKey = jwkSet.getKeyByIdOrSingleEntry(null);
+        Jwk foundKey = jwkSet.getKey(null);
         assertThat(foundKey, nullValue());
     }
 
-    private Jwk getJwk(String kid) {
+    private Jwk getMockJwk(String kid) {
         return new Jwk(kid, "type", "alg", "usage", Collections.<String>emptyList(), "certUrl",
                 Collections.<String>emptyList(), "certThumbprint", Collections.<String, Object>emptyMap());
     }


### PR DESCRIPTION
### Changes

Adds a JwkSet object. This is the first change towards improving the caching and supporting rotating signing keys.

Future PRs will expose the new `JwkSet` on the `JwkProvider`, as well as support caching of the JwkSet instead of individual keys.

### Testing

- [X] This change adds test coverage
- [X] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
