### PR TITLE
remove commons-io dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,6 @@ test {
 
 dependencies {
     implementation group: 'commons-codec', name: 'commons-codec', version:'1.13'
-    implementation group: 'commons-io', name: 'commons-io', version:'2.6'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.10.0.pr3'
     implementation group: 'com.google.guava', name: 'guava', version:'27.1-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.12'


### PR DESCRIPTION
### Changes

Removes the dependency on Apache commons-io.

IQ Server reports a vulnerability in commons-io relating to https://issues.apache.org/jira/browse/IO-559
Initially I was going to send a PR with a version bump similar to https://github.com/auth0/jwks-rsa-java/pull/26
However in checking whether the jwks-rsa library used the affected class from commons-io I noticed that the library doesn't appear to use commons-io at all. The build and test passes when removing the dependency so I figured it would be worth contributing that removal to avoid unnecessary dependencies and churn based on vulns or other issues with the dependency.

If I am wrong and this dependency is needed I can happily contribute a version bump instead.

### References
https://issues.apache.org/jira/browse/IO-559
https://github.com/auth0/jwks-rsa-java/pull/26

### Testing

I am unsure what testing other than the existing build and test is needed by maintainers to validate this change.

- [ ] This change adds test coverage (no new functionality to test)
- [ ] This change has been tested on the latest version of Java or why not (no new functionality to test)

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
