### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.11.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.12.1'
     }
 }
 
@@ -65,10 +65,10 @@ test {
 }
 
 dependencies {
-    implementation group: 'commons-codec', name: 'commons-codec', version:'1.13'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.10.0.pr3'
-    implementation group: 'com.google.guava', name: 'guava', version:'27.1-jre'
-    testImplementation group: 'junit', name: 'junit', version:'4.12'
+    implementation group: 'commons-codec', name: 'commons-codec', version:'1.15'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.11.3'
+    implementation group: 'com.google.guava', name: 'guava', version:'30.0-jre'
+    testImplementation group: 'junit', name: 'junit', version:'4.13.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'
 }


### PR DESCRIPTION
### Changes

This change contains dependency updates only.

The most important update is to update to Guava 30.0 to address [this vulnerability](https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415).

### References

- https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415

### Testing

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
