### PR TITLE
toString should return kty instead of kyt

### DIFF
--- a/src/main/java/com/auth0/jwk/Jwk.java
+++ b/src/main/java/com/auth0/jwk/Jwk.java
@@ -35,7 +35,7 @@ public class Jwk {
      * Creates a new Jwk
      *
      * @param id                    kid
-     * @param type                  kyt
+     * @param type                  kty
      * @param algorithm             alg
      * @param usage                 use
      * @param operations            key_ops
@@ -189,7 +189,7 @@ public class Jwk {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("kid", id)
-                .add("kyt", type)
+                .add("kty", type)
                 .add("alg", algorithm)
                 .add("use", usage)
                 .add("extras", additionalAttributes)


### PR DESCRIPTION
### Changes
The `Jwk.toString` seems to be wrongly returning `kyt` instead of `kty`:
https://github.com/auth0/jwks-rsa-java/blob/5d1e06c259769d7995dc67c1b2518894ec68a621/src/main/java/com/auth0/jwk/Jwk.java#L192

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
