### PR TITLE
Allow setting of custom headers

### DIFF
--- a/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
+++ b/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
@@ -2,6 +2,7 @@ package com.auth0.jwk;
 
 import java.net.Proxy;
 import java.net.URL;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.auth0.jwk.UrlJwkProvider.urlForDomain;
@@ -20,6 +21,7 @@ public class JwkProviderBuilder {
     private boolean cached;
     private BucketImpl bucket;
     private boolean rateLimited;
+    private Map<String, String> headers;
 
     /**
      * Creates a new Builder with the given URL where to load the jwks from.
@@ -127,12 +129,23 @@ public class JwkProviderBuilder {
     }
 
     /**
+     * Sets the headers to send on the request. Any headers set here will override the default headers ("accept" -> "application/json")
+     *
+     * @param headers a map of header keys to values to send on the request.
+     * @return this builder instance
+     */
+    public JwkProviderBuilder headers(Map<String, String> headers) {
+        this.headers = headers;
+        return this;
+    }
+
+    /**
      * Creates a {@link JwkProvider}
      *
      * @return a newly created {@link JwkProvider}
      */
     public JwkProvider build() {
-        JwkProvider urlProvider = new UrlJwkProvider(url, null, null, proxy);
+        JwkProvider urlProvider = new UrlJwkProvider(url, null, null, proxy, headers);
         if (this.rateLimited) {
             urlProvider = new RateLimitedJwkProvider(urlProvider, bucket);
         }

--- a/src/test/java/com/auth0/jwk/JwkProviderBuilderTest.java
+++ b/src/test/java/com/auth0/jwk/JwkProviderBuilderTest.java
@@ -7,6 +7,8 @@ import org.junit.rules.ExpectedException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.auth0.jwk.UrlJwkProvider.WELL_KNOWN_JWKS_PATH;
@@ -157,5 +159,19 @@ public class JwkProviderBuilderTest {
         assertThat(provider, notNullValue());
         UrlJwkProvider urlJwkProvider = (UrlJwkProvider) provider;
         assertThat(urlJwkProvider.proxy, equalTo(proxy));
+    }
+
+    @Test
+    public void shouldCreateForUrlWithCustomHeaders() throws Exception {
+        URL url = new URL(normalizedDomain + WELL_KNOWN_JWKS_PATH);
+        Map<String, String> headers = Collections.singletonMap("header", "value");
+        JwkProvider provider = new JwkProviderBuilder(url)
+                .rateLimited(false)
+                .cached(false)
+                .headers(headers)
+                .build();
+        assertThat(provider, notNullValue());
+        UrlJwkProvider urlJwkProvider = (UrlJwkProvider) provider;
+        assertThat(urlJwkProvider.headers, equalTo(headers));
     }
 }

--- a/src/test/java/com/auth0/jwk/UrlJwkProviderTest.java
+++ b/src/test/java/com/auth0/jwk/UrlJwkProviderTest.java
@@ -11,6 +11,8 @@ import org.mockito.stubbing.Answer;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.net.*;
+import java.util.Collections;
+import java.util.List;
 
 import static com.auth0.jwk.UrlJwkProvider.WELL_KNOWN_JWKS_PATH;
 import static org.hamcrest.Matchers.*;
@@ -275,6 +277,14 @@ public class UrlJwkProviderTest {
         assertThat(mockFactory.urlUsed.get(), is(url));
         assertThat(mockFactory.proxyUsed.get(), is(nullValue()));
 
+        // Test creation: custom headers
+        UrlJwkProvider urlJwkProviderWithHeaders = new UrlJwkProvider(url, connectTimeout, readTimeout, null,
+            Collections.singletonMap("Accept", "application/jwks-set+json"));
+        Jwk hJwk = urlJwkProviderWithHeaders.get("NkJCQzIyQzRBMEU4NjhGNUU4MzU4RkY0M0ZDQzkwOUQ0Q0VGNUMwQg");
+        assertNotNull(hJwk);
+        assertThat(mockFactory.urlUsed.get(), is(url));
+        assertThat(mockFactory.proxyUsed.get(), is(nullValue()));
+
         //Test creation: with Proxy
         Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 8080));
         URL pUrl = new URL("mock://localhost");
@@ -291,15 +301,16 @@ public class UrlJwkProviderTest {
         //Test 1: Configuration
         //Request Timeout assertions
         ArgumentCaptor<Integer> connectTimeoutCaptor = ArgumentCaptor.forClass(Integer.class);
-        verify(urlConnection, times(2)).setConnectTimeout(connectTimeoutCaptor.capture());
+        verify(urlConnection, times(3)).setConnectTimeout(connectTimeoutCaptor.capture());
         assertThat(connectTimeoutCaptor.getValue(), is(connectTimeout));
 
         ArgumentCaptor<Integer> readTimeoutCaptor = ArgumentCaptor.forClass(Integer.class);
-        verify(urlConnection, times(2)).setReadTimeout(readTimeoutCaptor.capture());
+        verify(urlConnection, times(3)).setReadTimeout(readTimeoutCaptor.capture());
         assertThat(readTimeoutCaptor.getValue(), is(readTimeout));
 
         //Request Headers assertions
         verify(urlConnection, times(2)).setRequestProperty("Accept", "application/json");
+        verify(urlConnection, times(1)).setRequestProperty("Accept", "application/jwks-set+json");
 
         //Test 2: Network errors
         Exception capturedException = null;


### PR DESCRIPTION
### Changes

Fixes #77 by allowing custom headers to be configured for the `UrlJwkProvider`. 

If headers are set, they override the default headers (default is `"Accept": "application/json"`.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
