### PR TITLE
Fix JavaDoc Errors

### DIFF
--- a/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
+++ b/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
@@ -129,7 +129,7 @@ public class JwkProviderBuilder {
     }
 
     /**
-     * Sets the headers to send on the request. Any headers set here will override the default headers ("accept" -> "application/json")
+     * Sets the headers to send on the request. Any headers set here will override the default headers ("Accept": "application/json")
      *
      * @param headers a map of header keys to values to send on the request.
      * @return this builder instance

--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -66,7 +66,7 @@ public class UrlJwkProvider implements JwkProvider {
      * @param connectTimeout connection timeout in milliseconds (default is null)
      * @param readTimeout    read timeout in milliseconds (default is null)
      * @param proxy          proxy server to use when making the connection (default is null)
-     * @param headers        a map of request header keys to values to send on the request. Default is "accept -> application/json".
+     * @param headers        a map of request header keys to values to send on the request. Default is "Accept: application/json".
      */
     public UrlJwkProvider(URL url, Integer connectTimeout, Integer readTimeout, Proxy proxy, Map<String, String> headers) {
         checkArgument(url != null, "A non-null url is required");


### PR DESCRIPTION
### Changes

Fixes JavaDoc errors: ` error: bad use of '>'`

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
