### PR TITLE
Remove commons-codec dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'commons-codec', name: 'commons-codec', version:'1.15'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.11.3'
     implementation group: 'com.google.guava', name: 'guava', version:'30.0-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.13.1'

--- a/src/main/java/com/auth0/jwk/Jwk.java
+++ b/src/main/java/com/auth0/jwk/Jwk.java
@@ -2,7 +2,6 @@ package com.auth0.jwk;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
-import org.apache.commons.codec.binary.Base64;
 
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
@@ -16,6 +15,7 @@ import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -182,8 +182,8 @@ public class Jwk {
             case ALGORITHM_RSA:
                 try {
                     KeyFactory kf = KeyFactory.getInstance(ALGORITHM_RSA);
-                    BigInteger modulus = new BigInteger(1, Base64.decodeBase64(stringValue("n")));
-                    BigInteger exponent = new BigInteger(1, Base64.decodeBase64(stringValue("e")));
+                    BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(stringValue("n")));
+                    BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(stringValue("e")));
                     publicKey = kf.generatePublic(new RSAPublicKeySpec(modulus, exponent));
                 } catch (InvalidKeySpecException e) {
                     throw new InvalidPublicKeyException("Invalid public key", e);
@@ -195,8 +195,8 @@ public class Jwk {
             case ALGORITHM_ELLIPTIC_CURVE:
                 try {
                     KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM_ELLIPTIC_CURVE);
-                    ECPoint ecPoint = new ECPoint(new BigInteger(Base64.decodeBase64(stringValue("x"))),
-                            new BigInteger(Base64.decodeBase64(stringValue("y"))));
+                    ECPoint ecPoint = new ECPoint(new BigInteger(Base64.getUrlDecoder().decode(stringValue("x"))),
+                            new BigInteger(Base64.getUrlDecoder().decode(stringValue("y"))));
                     AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance(ALGORITHM_ELLIPTIC_CURVE);
 
                     String curve = stringValue("crv");

--- a/src/test/java/com/auth0/jwk/JwkTest.java
+++ b/src/test/java/com/auth0/jwk/JwkTest.java
@@ -2,7 +2,6 @@ package com.auth0.jwk;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -10,6 +9,7 @@ import org.junit.rules.ExpectedException;
 import java.security.SecureRandom;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -213,7 +213,7 @@ public class JwkTest {
     private static String randomKeyId() {
         byte[] bytes = new byte[50];
         new SecureRandom().nextBytes(bytes);
-        return Base64.encodeBase64String(bytes);
+        return Base64.getEncoder().encodeToString(bytes);
     }
 
     private static Map<String, Object> unsupportedValues(String kid) {


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:
1. Migrated from commons-codec Base64 to java.util.Base64
2. Commons-codec wasn't used after migration, so i removed this dependency

### References
https://github.com/auth0/jwks-rsa-java/issues/118

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [x] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
