### PR TITLE
Remove bintray gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'com.jfrog.bintray'
     id 'com.auth0.gradle.oss-library.java'
 }
 group = 'com.auth0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,6 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
-        id 'com.jfrog.bintray' version '1.8.5'
         id 'com.auth0.gradle.oss-library.java' version '0.15.1'
     }
 }


### PR DESCRIPTION
This plugin is no longer required, as we no longer upload the packages to Bintray but to Sonatype instead. We still use the OSS plugin for that task.