### PR TITLE
Update OSS release plugin version

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
-        id 'com.auth0.gradle.oss-library.java' version '0.15.1'
+        id 'com.auth0.gradle.oss-library.java' version '0.16.0'
     }
 }
 rootProject.name = 'jwks-rsa'


### PR DESCRIPTION
### Changes

This PR updates the OSS release plugin version to 0.16.0, which makes use of a newer Javadoc HTML template.

I also removed the bintray plugin which is no longer used.