### PR TITLE
Use Duration in JwkProviderBuilder

### DIFF
--- a/src/main/java/com/auth0/jwk/GuavaCachedJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/GuavaCachedJwkProvider.java
@@ -3,6 +3,7 @@ package com.auth0.jwk;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
+import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -24,7 +25,7 @@ public class GuavaCachedJwkProvider implements JwkProvider {
      * @param provider fallback provider to use when jwk is not cached
      */
     public GuavaCachedJwkProvider(final JwkProvider provider) {
-        this(provider, 5, 10, TimeUnit.MINUTES);
+        this(provider, 5, Duration.ofMinutes(10));
     }
 
     /**
@@ -34,12 +35,24 @@ public class GuavaCachedJwkProvider implements JwkProvider {
      * @param size        number of jwt to cache
      * @param expiresIn   amount of time a jwk will live in the cache
      * @param expiresUnit unit of the expiresIn parameter
+     * @deprecated prefer the use of {@link GuavaCachedJwkProvider#GuavaCachedJwkProvider(JwkProvider, long, Duration)}
      */
     public GuavaCachedJwkProvider(final JwkProvider provider, long size, long expiresIn, TimeUnit expiresUnit) {
+        this(provider, size, Duration.of(expiresIn, Util.toChronoUnit(expiresUnit)));
+    }
+
+    /**
+     * Creates a new cached provider specifying cache size and ttl
+     *
+     * @param provider    fallback provider to use when jwk is not cached
+     * @param size        number of jwt to cache
+     * @param expiresIn   amount of time a jwk will live in the cache
+     */
+    public GuavaCachedJwkProvider(final JwkProvider provider, long size, Duration expiresIn) {
         this.provider = provider;
         this.cache = CacheBuilder.newBuilder()
                 .maximumSize(size)
-                .expireAfterWrite(expiresIn, expiresUnit)
+                .expireAfterWrite(expiresIn)
                 .build();
     }
 

--- a/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
+++ b/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
@@ -2,6 +2,7 @@ package com.auth0.jwk;
 
 import java.net.Proxy;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -15,8 +16,7 @@ public class JwkProviderBuilder {
 
     private final URL url;
     private Proxy proxy;
-    private TimeUnit expiresUnit;
-    private long expiresIn;
+    private Duration expiresIn;
     private long cacheSize;
     private boolean cached;
     private BucketImpl bucket;
@@ -35,8 +35,7 @@ public class JwkProviderBuilder {
         }
         this.url = url;
         this.cached = true;
-        this.expiresIn = 10;
-        this.expiresUnit = TimeUnit.HOURS;
+        this.expiresIn = Duration.ofHours(10);
         this.cacheSize = 5;
         this.rateLimited = true;
         this.bucket = new BucketImpl(10, 1, TimeUnit.MINUTES);
@@ -82,15 +81,26 @@ public class JwkProviderBuilder {
      *
      * @param cacheSize number of jwk to cache
      * @param expiresIn amount of time the jwk will be cached
-     * @param unit      unit of time for the expire of jwk
      * @return the builder
      */
-    public JwkProviderBuilder cached(long cacheSize, long expiresIn, TimeUnit unit) {
+    public JwkProviderBuilder cached(long cacheSize, Duration expiresIn) {
         this.cached = true;
         this.cacheSize = cacheSize;
         this.expiresIn = expiresIn;
-        this.expiresUnit = unit;
         return this;
+    }
+
+    /**
+     * Enable the cache specifying size and expire time.
+     *
+     * @param cacheSize number of jwk to cache
+     * @param expiresIn amount of time the jwk will be cached
+     * @param unit      unit of time for the expire of jwk
+     * @return the builder
+     * @deprecated prefer the use of {@link JwkProviderBuilder#cached(long, Duration)}
+     */
+    public JwkProviderBuilder cached(long cacheSize, long expiresIn, TimeUnit unit) {
+        return this.cached(cacheSize, Duration.of(expiresIn, Util.toChronoUnit(unit)));
     }
 
     /**
@@ -150,7 +160,7 @@ public class JwkProviderBuilder {
             urlProvider = new RateLimitedJwkProvider(urlProvider, bucket);
         }
         if (this.cached) {
-            urlProvider = new GuavaCachedJwkProvider(urlProvider, cacheSize, expiresIn, expiresUnit);
+            urlProvider = new GuavaCachedJwkProvider(urlProvider, cacheSize, expiresIn);
         }
         return urlProvider;
     }

--- a/src/main/java/com/auth0/jwk/Util.java
+++ b/src/main/java/com/auth0/jwk/Util.java
@@ -1,5 +1,10 @@
 package com.auth0.jwk;
 
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 class Util {
     static boolean isNullOrEmpty(String s) {
         return s == null || s.isEmpty();
@@ -9,5 +14,25 @@ class Util {
         if (!arg) {
             throw new IllegalArgumentException(String.valueOf(message));
         }
+    }
+
+    private static Map<TimeUnit, ChronoUnit> chronoByTimes = new HashMap<>();
+    static {
+        chronoByTimes.put(TimeUnit.NANOSECONDS, ChronoUnit.NANOS);
+        chronoByTimes.put(TimeUnit.MICROSECONDS, ChronoUnit.MICROS);
+        chronoByTimes.put(TimeUnit.MILLISECONDS, ChronoUnit.MILLIS);
+        chronoByTimes.put(TimeUnit.SECONDS, ChronoUnit.SECONDS);
+        chronoByTimes.put(TimeUnit.MINUTES, ChronoUnit.MINUTES);
+        chronoByTimes.put(TimeUnit.HOURS, ChronoUnit.HOURS);
+        chronoByTimes.put(TimeUnit.DAYS, ChronoUnit.DAYS);
+    }
+
+    // This method replaces the JDK 9 implementation TimeUnit.toChronoUnit
+    static ChronoUnit toChronoUnit(TimeUnit unit) {
+        ChronoUnit chrono = chronoByTimes.get(unit);
+        if (chrono == null) {
+            throw new IllegalArgumentException(String.format("Invalid TimeUnit %s", unit.toString()));
+        }
+        return chrono;
     }
 }


### PR DESCRIPTION
### Changes

I added alternative constructors to `JwkProviderBuilder` and `GuavaCachedJwkProvider` to use a `Duration` as amount of time to cache the data.

### References

Should fix #92 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [*] This change adds test coverage
- [*] This change has been tested on the latest version of Java or why not

### Checklist

- [*] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [*] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [*] All existing and new tests complete without errors
