### PR TITLE
Expose read/connect timeouts in the JwkProviderBuilder class

### DIFF
--- a/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
+++ b/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
@@ -16,6 +16,8 @@ public class JwkProviderBuilder {
     private final URL url;
     private Proxy proxy;
     private TimeUnit expiresUnit;
+    private Integer connectTimeout;
+    private Integer readTimeout;
     private long expiresIn;
     private long cacheSize;
     private boolean cached;
@@ -129,6 +131,22 @@ public class JwkProviderBuilder {
     }
 
     /**
+     * Sets a custom connect and read timeout values.
+     * When this method is not called, the default timeout values
+     * will be those defined by the {@link UrlJwkProvider} implementation.
+     *
+     * @param connectTimeout connection timeout in milliseconds.
+     * @param readTimeout read timeout in milliseconds.
+     * @see UrlJwkProvider
+     * @return the builder
+     */
+    public JwkProviderBuilder timeouts(int connectTimeout, int readTimeout) {
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+        return this;
+    }
+
+    /**
      * Sets the headers to send on the request. Any headers set here will override the default headers ("Accept": "application/json")
      *
      * @param headers a map of header keys to values to send on the request.
@@ -145,7 +163,7 @@ public class JwkProviderBuilder {
      * @return a newly created {@link JwkProvider}
      */
     public JwkProvider build() {
-        JwkProvider urlProvider = new UrlJwkProvider(url, null, null, proxy, headers);
+        JwkProvider urlProvider = new UrlJwkProvider(url, connectTimeout, readTimeout, proxy, headers);
         if (this.rateLimited) {
             urlProvider = new RateLimitedJwkProvider(urlProvider, bucket);
         }

--- a/src/main/java/com/auth0/jwk/UrlJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/UrlJwkProvider.java
@@ -5,12 +5,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.Proxy;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLConnection;
+import java.net.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,10 +23,11 @@ public class UrlJwkProvider implements JwkProvider {
     final URL url;
     final Proxy proxy;
     final Map<String, String> headers;
-    private final Integer connectTimeout;
-    private final Integer readTimeout;
+    final Integer connectTimeout;
+    final Integer readTimeout;
 
     private final ObjectReader reader;
+
     /**
      * Creates a provider that loads from the given URL
      *
@@ -74,7 +70,7 @@ public class UrlJwkProvider implements JwkProvider {
         this.reader = new ObjectMapper().readerFor(Map.class);
 
         this.headers = (headers == null) ?
-            Collections.singletonMap("Accept", "application/json") : headers;
+                Collections.singletonMap("Accept", "application/json") : headers;
     }
 
     /**


### PR DESCRIPTION
### Changes

This exposes a method `timeouts` that allows configuring the read/connect timeouts of the base `UrlJwkProvider` class.

### References

Closes https://github.com/auth0/jwks-rsa-java/issues/132
