### PR TITLE
Update Jackson dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.11.3'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.12.6'
     implementation group: 'com.google.guava', name: 'guava', version:'30.0-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.13.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'


### PR DESCRIPTION
### Changes

We are upgrading Jackson dependency to 12.6 due to vulnerability in the current version

### References
[Link](https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698)

### Testing
Since this is a dependency upgrade, we checked it using our existing unit tests