### PR TITLE
Configure cache with TimeUnit instead of Duration

### DIFF
--- a/src/main/java/com/auth0/jwk/GuavaCachedJwkProvider.java
+++ b/src/main/java/com/auth0/jwk/GuavaCachedJwkProvider.java
@@ -37,7 +37,12 @@ public class GuavaCachedJwkProvider implements JwkProvider {
      * @param expiresUnit unit of the expiresIn parameter
      */
     public GuavaCachedJwkProvider(final JwkProvider provider, long size, long expiresIn, TimeUnit expiresUnit) {
-        this(provider, size, Duration.ofSeconds(expiresUnit.toSeconds(expiresIn)));
+        this.provider = provider;
+        this.cache = CacheBuilder.newBuilder()
+                .maximumSize(size)
+                // configure using timeunit; see https://github.com/auth0/jwks-rsa-java/issues/136
+                .expireAfterWrite(expiresIn, expiresUnit)
+                .build();
     }
 
     /**
@@ -48,11 +53,7 @@ public class GuavaCachedJwkProvider implements JwkProvider {
      * @param expiresIn   amount of time a jwk will live in the cache
      */
     public GuavaCachedJwkProvider(final JwkProvider provider, long size, Duration expiresIn) {
-        this.provider = provider;
-        this.cache = CacheBuilder.newBuilder()
-                .maximumSize(size)
-                .expireAfterWrite(expiresIn)
-                .build();
+        this(provider, size, expiresIn.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     @Override


### PR DESCRIPTION
As reported in #136, the introduction of support for `Duration` causes an issue when using `com.google.guava:guava:30.1.1-android`, as the Android version does not support configuration with `Duration` ([the comment here](https://github.com/google/guava/blob/master/android/guava/src/com/google/common/cache/CacheBuilder.java#L698) suggests it should be added). In this case we can just invert the constructor delegation of `GuavaCachedJwkProvider` to call Guava using `TimeUnit`.

In my tests using a project with a dependency on `com.google.guava:guava:30.1.1-android`, this change fixed the reported issue.