### PR TITLE
Security: Bump `jackson-databind` to 2.13.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.13.2.1'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.13.2.2'
     implementation group: 'com.google.guava', name: 'guava', version:'30.0-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.13.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.13.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.13.2.1'
     implementation group: 'com.google.guava', name: 'guava', version:'30.0-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.13.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'


### PR DESCRIPTION
This PR bumps the `jackson-databind` dependency to 2.13.2.2 to address [CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) in that library

---

~~Re: [FasterXML/jackson-databind#3428](https://togithub.com/FasterXML/jackson-databind/issues/3428)
Build is currently failing due to an upstream issue; holding until resolved.~~

---

A package fix was released as 2.13.2.2. I've updated the PR and marked as ready for review.