### PR TITLE
Update Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@3
+
 commands:
   checkout-and-build:
     steps:
@@ -19,10 +22,7 @@ commands:
   run-tests:
     steps:
       - run: ./gradlew check jacocoTestReport --continue --console=plain
-      - run:
-          name: Upload Coverage
-          when: on_success
-          command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1
+      - codecov/upload
   run-api-diff:
     steps:
       # run apiDiff task


### PR DESCRIPTION
This PR replaces the deprecated bash uploader for Codecov in our CircleCI workflow with the recommended/supported Orb approach