### PR TITLE
Clarify that getting a JWK is a synchronous operation

### DIFF
--- a/src/main/java/com/auth0/jwk/JwkProvider.java
+++ b/src/main/java/com/auth0/jwk/JwkProvider.java
@@ -6,9 +6,10 @@ package com.auth0.jwk;
 @SuppressWarnings("WeakerAccess")
 public interface JwkProvider {
     /**
-     * Returns a jwk using the kid value
-     * @param keyId value of kid found in JWT
-     * @return a jwk
+     * Attempts to get a JWK using the Key ID value. Note that implementations are synchronous (blocking).
+     *
+     * @param keyId value of the kid found in a JWT
+     * @return a JWK
      * @throws SigningKeyNotFoundException if no jwk can be found using the given kid
      */
     Jwk get(String keyId) throws JwkException;


### PR DESCRIPTION
Documentation-only change to clarify that any of the `get(String keyId)` implementations of `JwkProvider` are synchronous. Adding async support is something we can consider in the future (may require a different caching provider, which may also have other benefits, but not a trivial change).

Closes #147 