### PR TITLE
[SDK-3623] Fix ECPoint construction for getting public key

### DIFF
--- a/src/main/java/com/auth0/jwk/Jwk.java
+++ b/src/main/java/com/auth0/jwk/Jwk.java
@@ -193,8 +193,8 @@ public class Jwk {
             case ALGORITHM_ELLIPTIC_CURVE:
                 try {
                     KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM_ELLIPTIC_CURVE);
-                    ECPoint ecPoint = new ECPoint(new BigInteger(Base64.getUrlDecoder().decode(stringValue("x"))),
-                            new BigInteger(Base64.getUrlDecoder().decode(stringValue("y"))));
+                    ECPoint ecPoint = new ECPoint(new BigInteger(1, Base64.getUrlDecoder().decode(stringValue("x"))),
+                            new BigInteger(1, Base64.getUrlDecoder().decode(stringValue("y"))));
                     AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance(ALGORITHM_ELLIPTIC_CURVE);
 
                     String curve = stringValue("crv");


### PR DESCRIPTION
Fixes #149. As discussed in #149, the coordinates should be deserialized using a `BigInteger` with a positive sigsum.