### PR TITLE
Bump `com.fasterxml.jackson.core:jackson-databind` to 2.13.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.13.2.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.13.4.2'
     implementation group: 'com.google.guava', name: 'guava', version:'30.0-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.13.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'


### PR DESCRIPTION
Resolves https://www.cve.org/CVERecord?id=CVE-2022-42003