### PR TITLE
README: Fix provider.get code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ JwkProvider provider = new JwkProviderBuilder("https://samples.auth0.com/")
 
 A `Jwk` can be obtained using the `get(String keyId)` method:
 
-``java
+```java
 Jwk jwk = provider.get("{kid of the signing key}"); // throws Exception when not found or can't get one
-``
+```
 
 The provider can be configured to cache JWKs to avoid unnecessary network requests, as well as only fetch the JWKs within a defined rate limit:
 


### PR DESCRIPTION
### Changes

Correcting the code example for `provider.get` in `README.md` by using a code block highlighted as Java, as was probably intended.

I apologize if this PR is unnecessary and nitpicky, but I do believe that the change is benefitting to the first impression of the repo.

### Testing

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] ~All existing and new tests complete without errors~ This PR does not change code.
