### PR TITLE
Release 0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [0.21.3](https://github.com/auth0/jwks-rsa-java/tree/0.21.3) (2023-01-11)
+[Full Changelog](https://github.com/auth0/jwks-rsa-java/compare/0.21.2...0.21.3)
+
+This patch release uses an updated signing key for verification as part of our commitment to best security practices.
+Please review [the README note for additional details.](https://github.com/auth0/jwks-rsa-java/blob/master/README.md)
+
+**Security**
+- Bump `jackson-databind` dependency to 2.13.4.2 [\#162](https://github.com/auth0/jwks-rsa-java/pull/162) ([evansims](https://github.com/evansims))
+
+**Changed**
+- Update Gradle wrapper to 6.9.2 [\#156](https://github.com/auth0/jwks-rsa-java/pull/156) ([jimmyjames](https://github.com/jimmyjames))
+
 ## [0.21.2](https://github.com/auth0/jwks-rsa-java/tree/0.21.2) (2022-09-15)
 [Full Changelog](https://github.com/auth0/jwks-rsa-java/compare/0.21.1...0.21.2)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.auth0/jwks-rsa.svg?style=flat-square)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%20com.auth0%20a%3Ajwks-rsa)
 [![javadoc](https://javadoc.io/badge2/com.auth0/jwks-rsa-java/javadoc.svg)](https://javadoc.io/doc/com.auth0/jwks-rsa)
 
+> **Note**
+> As part of our ongoing commitment to best security practices, we have rotated the signing keys used to sign previous releases of this SDK. As a result, new patch builds have been released using the new signing key. Please upgrade at your earliest convenience.
+> 
+> While this change won't affect most developers, if you have implemented a dependency signature validation step in your build process, you may notice a warning that past releases can't be verified. This is expected, and a result of the key rotation process. Updating to the latest version will resolve this for you.
+
 :books: [Documentation](#documentation) - :rocket: [Getting Started](#getting-started) - :computer: [API Reference](#api-reference) :speech_balloon: [Feedback](#feedback)
 
 ## Documentation
@@ -26,14 +31,14 @@ Add the dependency via Maven:
 <dependency>
   <groupId>com.auth0</groupId>
   <artifactId>jwks-rsa</artifactId>
-  <version>0.21.2</version>
+  <version>0.21.3</version>
 </dependency>
 ```
 
 or Gradle:
 
 ```gradle
-implementation 'com.auth0:jwks-rsa:0.21.2'
+implementation 'com.auth0:jwks-rsa:0.21.3'
 ```
 
 ### Usage


### PR DESCRIPTION
[Full Changelog](https://github.com/auth0/jwks-rsa-java/compare/0.21.2...0.21.3)

This patch release uses an updated signing key for verification as part of our commitment to best security practices.
Please review [the README note for additional details.](https://github.com/auth0/jwks-rsa-java/blob/master/README.md)

**Security**
- Bump `jackson-databind` dependency to 2.13.4.2 [\#162](https://github.com/auth0/jwks-rsa-java/pull/162) ([evansims](https://github.com/evansims))