### PR TITLE
Throw proper exception from cached provider

### DIFF
--- a/src/test/java/com/auth0/jwk/GuavaCachedJwkProviderTest.java
+++ b/src/test/java/com/auth0/jwk/GuavaCachedJwkProviderTest.java
@@ -30,7 +30,7 @@ public class GuavaCachedJwkProviderTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         provider = new GuavaCachedJwkProvider(fallback);
     }
 
@@ -38,6 +38,27 @@ public class GuavaCachedJwkProviderTest {
     public void shouldFailToGetSingleWhenNotExists() throws Exception {
         expectedException.expect(SigningKeyNotFoundException.class);
         when(fallback.get(anyString())).thenThrow(new SigningKeyNotFoundException("TEST!", null));
+        provider.get(KID);
+    }
+
+    @Test
+    public void shouldThrowSigningKeyNotFoundException() throws Exception {
+        expectedException.expect(SigningKeyNotFoundException.class);
+        when(fallback.get(anyString())).thenThrow(new SigningKeyNotFoundException("TEST!", null));
+        provider.get(KID);
+    }
+
+    @Test
+    public void shouldThrowRateLimitReachedException() throws Exception {
+        expectedException.expect(RateLimitReachedException.class);
+        when(fallback.get(anyString())).thenThrow(new RateLimitReachedException(1234));
+        provider.get(KID);
+    }
+
+    @Test
+    public void shouldThrowNetworkException() throws Exception {
+        expectedException.expect(NetworkException.class);
+        when(fallback.get(anyString())).thenThrow(new NetworkException("TEST!", null));
         provider.get(KID);
     }
 
@@ -77,7 +98,7 @@ public class GuavaCachedJwkProviderTest {
     }
 
     @Test
-    public void shouldGetBaseProvider() throws Exception {
+    public void shouldGetBaseProvider() {
         assertThat(provider.getBaseProvider(), equalTo(fallback));
     }
 }


### PR DESCRIPTION
Prior to this change, if using a cached JWK provider (the default), any exception caught when accessing the JWK would be a `SigningKeyNotFoundException`, with a cause of `ExecutionException` (thrown by the cache provider). 

Since the cause of an exception may be for different reasons (e.g., network exception, KID not found), developers would need to unwrap the `SigningKeyNotFoundException` to get the `ExecutionException`, which itself would contain the specific reason for failure (some `JwkException`). 

As raised in #165, this is cumbersome. Instead, this PR throws the causing exception directly, so that developers can more easily identify why the operation failed.

Fixes #165 