### PR TITLE
Feature/update guava dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ repositories {
 
 dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.13.4.2'
-    implementation group: 'com.google.guava', name: 'guava', version:'30.0-jre'
+    implementation group: 'com.google.guava', name: 'guava', version:'31.1-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.13.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'


### PR DESCRIPTION
### Changes

Google Guava dependency updated to 31.1 since the 30.0 version is showing as "Out of Date".

### References

https://github.com/google/guava


### Checklist

- [X ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X ] All existing and new tests complete without errors
