### PR TITLE
Replace guava with caffine.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ repositories {
 
 dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.15.0'
-    implementation group: 'com.google.guava', name: 'guava', version:'31.1-jre'
+    implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.9.3'
     testImplementation group: 'junit', name: 'junit', version:'4.13.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'

--- a/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
+++ b/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
@@ -177,7 +177,7 @@ public class JwkProviderBuilder {
             urlProvider = new RateLimitedJwkProvider(urlProvider, bucket);
         }
         if (this.cached) {
-            urlProvider = new GuavaCachedJwkProvider(urlProvider, cacheSize, expiresIn);
+            urlProvider = new CaffineCachedJwkProvider(urlProvider, cacheSize, expiresIn);
         }
         return urlProvider;
     }

--- a/src/test/java/com/auth0/jwk/CaffineCachedJwkProviderTest.java
+++ b/src/test/java/com/auth0/jwk/CaffineCachedJwkProviderTest.java
@@ -15,10 +15,10 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-public class GuavaCachedJwkProviderTest {
+public class CaffineCachedJwkProviderTest {
 
     private static final String KID = "KID";
-    private GuavaCachedJwkProvider provider;
+    private CaffineCachedJwkProvider provider;
 
     @Mock
     private JwkProvider fallback;
@@ -31,7 +31,7 @@ public class GuavaCachedJwkProviderTest {
 
     @Before
     public void setUp() {
-        provider = new GuavaCachedJwkProvider(fallback);
+        provider = new CaffineCachedJwkProvider(fallback);
     }
 
     @Test
@@ -79,12 +79,12 @@ public class GuavaCachedJwkProviderTest {
 
     @Test
     public void shouldCacheWhenIdMatchesDefaultMissingIdKey() throws Exception {
-        when(fallback.get(eq(GuavaCachedJwkProvider.NULL_KID_KEY))).thenReturn(jwk);
-        assertThat(provider.get(GuavaCachedJwkProvider.NULL_KID_KEY), equalTo(jwk));
-        verify(fallback).get(eq(GuavaCachedJwkProvider.NULL_KID_KEY));
+        when(fallback.get(eq(CaffineCachedJwkProvider.NULL_KID_KEY))).thenReturn(jwk);
+        assertThat(provider.get(CaffineCachedJwkProvider.NULL_KID_KEY), equalTo(jwk));
+        verify(fallback).get(eq(CaffineCachedJwkProvider.NULL_KID_KEY));
 
         verifyNoMoreInteractions(fallback);
-        assertThat(provider.get(GuavaCachedJwkProvider.NULL_KID_KEY), equalTo(jwk));
+        assertThat(provider.get(CaffineCachedJwkProvider.NULL_KID_KEY), equalTo(jwk));
     }
 
     @Test

--- a/src/test/java/com/auth0/jwk/JwkProviderBuilderTest.java
+++ b/src/test/java/com/auth0/jwk/JwkProviderBuilderTest.java
@@ -60,8 +60,8 @@ public class JwkProviderBuilderTest {
                 .cached(true)
                 .build();
         assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
-        assertThat(((GuavaCachedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
+        assertThat(provider, instanceOf(CaffineCachedJwkProvider.class));
+        assertThat(((CaffineCachedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
     }
 
     @Test
@@ -71,8 +71,8 @@ public class JwkProviderBuilderTest {
                 .cached(10, 24, TimeUnit.HOURS)
                 .build();
         assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
-        assertThat(((GuavaCachedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
+        assertThat(provider, instanceOf(CaffineCachedJwkProvider.class));
+        assertThat(((CaffineCachedJwkProvider) provider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
     }
 
     @Test
@@ -104,8 +104,8 @@ public class JwkProviderBuilderTest {
                 .rateLimited(true)
                 .build();
         assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
-        JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
+        assertThat(provider, instanceOf(CaffineCachedJwkProvider.class));
+        JwkProvider baseProvider = ((CaffineCachedJwkProvider) provider).getBaseProvider();
         assertThat(baseProvider, instanceOf(RateLimitedJwkProvider.class));
         assertThat(((RateLimitedJwkProvider) baseProvider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
     }
@@ -117,8 +117,8 @@ public class JwkProviderBuilderTest {
                 .rateLimited(10, 24, TimeUnit.HOURS)
                 .build();
         assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
-        JwkProvider baseProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
+        assertThat(provider, instanceOf(CaffineCachedJwkProvider.class));
+        JwkProvider baseProvider = ((CaffineCachedJwkProvider) provider).getBaseProvider();
         assertThat(baseProvider, instanceOf(RateLimitedJwkProvider.class));
         assertThat(((RateLimitedJwkProvider) baseProvider).getBaseProvider(), instanceOf(UrlJwkProvider.class));
     }
@@ -127,9 +127,9 @@ public class JwkProviderBuilderTest {
     public void shouldCreateCachedAndRateLimitedProviderByDefault() {
         JwkProvider provider = new JwkProviderBuilder(domain).build();
         assertThat(provider, notNullValue());
-        assertThat(provider, instanceOf(GuavaCachedJwkProvider.class));
+        assertThat(provider, instanceOf(CaffineCachedJwkProvider.class));
 
-        JwkProvider wrappedCachedProvider = ((GuavaCachedJwkProvider) provider).getBaseProvider();
+        JwkProvider wrappedCachedProvider = ((CaffineCachedJwkProvider) provider).getBaseProvider();
         assertThat(wrappedCachedProvider, instanceOf(RateLimitedJwkProvider.class));
 
         JwkProvider wrappedRateLimitedProvider = ((RateLimitedJwkProvider) wrappedCachedProvider).getBaseProvider();

--- a/src/test/java/com/auth0/jwk/JwkTest.java
+++ b/src/test/java/com/auth0/jwk/JwkTest.java
@@ -1,7 +1,6 @@
 package com.auth0.jwk;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -9,9 +8,7 @@ import org.junit.rules.ExpectedException;
 import java.security.SecureRandom;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
-import java.util.Base64;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -43,7 +40,7 @@ public class JwkTest {
     private static final String MODULUS = "vGChUGMTWZNfRsXxd-BtzC4RDYOMqtIhWHol--HNib5SgudWBg6rEcxvR6LWrx57N6vfo68wwT9_FHlZpaK6NXA_dWFW4f3NftfWLL7Bqy90sO4vijM6LMSE6rnl5VB9_Gsynk7_jyTgYWdTwKur0YRec93eha9oCEXmy7Ob1I2dJ8OQmv2GlvA7XZalMxAq4rFnXLzNQ7hCsHrUJP1p7_7SolWm9vTokkmckzSI_mAH2R27Z56DmI7jUkL9fLU-jz-fz4bkNg-mPz4R-kUmM_ld3-xvto79BtxJvOw5qqtLNnRjiDzoqRv-WrBdw5Vj8Pvrg1fwscfVWHlmq-1pFQ";
     private static final String EXPONENT = "AQAB";
     private static final String CERT_CHAIN = "CERT_CHAIN";
-    private static final List<String> KEY_OPS_LIST = Lists.newArrayList("sign");
+    private static final List<String> KEY_OPS_LIST = Arrays.asList("sign");
     private static final String KEY_OPS_STRING = "sign";
 
     @Rule
@@ -164,7 +161,7 @@ public class JwkTest {
     @Test
     public void shouldReturnPublicKeyForEmptyKeyOpsParam() throws Exception {
         final String kid = randomKeyId();
-        Map<String, Object> values = publicKeyRsaValues(kid, Lists.newArrayList());
+        Map<String, Object> values = publicKeyRsaValues(kid, Arrays.asList());
         Jwk jwk = Jwk.fromValues(values);
 
         assertThat(jwk.getPublicKey(), notNullValue());
@@ -217,7 +214,7 @@ public class JwkTest {
     }
 
     private static Map<String, Object> unsupportedValues(String kid) {
-        Map<String, Object> values = Maps.newHashMap();
+        Map<String, Object> values = new HashMap();
         values.put("alg", "AES_256");
         values.put("kty", AES);
         values.put("use", SIG);
@@ -226,12 +223,12 @@ public class JwkTest {
     }
 
     private static Map<String, Object> publicKeyRsaValues(String kid, Object keyOps) {
-        Map<String, Object> values = Maps.newHashMap();
+        Map<String, Object> values = new HashMap();
         values.put("alg", RS_256);
         values.put("kty", RSA);
         values.put("use", SIG);
         values.put("key_ops", keyOps);
-        values.put("x5c", Lists.newArrayList(CERT_CHAIN));
+        values.put("x5c", Arrays.asList(CERT_CHAIN));
         values.put("x5t", THUMBPRINT);
         values.put("kid", kid);
         values.put("n", MODULUS);
@@ -240,7 +237,7 @@ public class JwkTest {
     }
 
     private static Map<String, Object> publicKeyEllipticCurveValues(String kid, String alg, Object keyOps, String crv, String x, String y) {
-        Map<String, Object> values = Maps.newHashMap();
+        Map<String, Object> values = new HashMap();
         values.put("alg", alg);
         values.put("kty", EC);
         values.put("use", SIG);


### PR DESCRIPTION
Caffine is a focussed library that just provides caching. It has similar behaviour to guava's caching library.

This commit replaces guava's cache with caffine and remove other minor uses of guava APIs.

### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
None.

- Classes and methods added, deleted, deprecated, or changed
Remove GuavaCachedJwkProvider and added CaffineCachedJwkProvider

- Screenshots of new or changed UI, if applicable
None.

- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)

No public changes.

- Any alternative designs or approaches considered

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
