### PR TITLE
Updating the javadocs to include the default caching behaviour.

### DIFF
--- a/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
+++ b/src/main/java/com/auth0/jwk/JwkProviderBuilder.java
@@ -68,7 +68,7 @@ public class JwkProviderBuilder {
     }
 
     /**
-     * Toggle the cache of Jwk. By default the provider will use cache.
+     * Toggle the cache of Jwk. By default, the provider will use a cache size of 5 and a duration of 10 hours.
      *
      * @param cached if the provider should cache jwks
      * @return the builder


### PR DESCRIPTION
### Changes
I've update the Javadocs for
https://github.com/auth0/jwks-rsa-java/blob/7eb15a274338dfed57bef063fe36291da5d9fae0/src/main/java/com/auth0/jwk/JwkProviderBuilder.java#L76

To better describe the default caching behaviour when you don't specify the cache size and / or the timeout duration.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
