### PR TITLE
chore(security): Update and pin Graddle workflow actions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "validation/gradlew"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@8d49e559aae34d3e0eb16cde532684bc9702762b # pin@1.0.6


### PR DESCRIPTION
This PR pins the `gradle/wrapper-validation-action` third-party action to a full-length commit SHA — that of release 1.0.6.

Pinning an action to a full-length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository. https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

This PR also updates the official `actions/checkout` action to use the newer v3 release.