### PR TITLE
Bump guava version to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,3 +75,12 @@ task exportVersion()  {
         new File(rootDir, "version.txt").text = "$version"
     }
 }
+
+sourceSets.all {
+    configurations.getByName(runtimeClasspathConfigurationName) {
+        attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
+    }
+    configurations.getByName(compileClasspathConfigurationName) {
+        attributes.attribute(Attribute.of("org.gradle.jvm.environment", String), "standard-jvm")
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ repositories {
 
 dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.15.0'
-    implementation group: 'com.google.guava', name: 'guava', version:'31.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version:'32.1.1-jre'
     testImplementation group: 'junit', name: 'junit', version:'4.13.1'
     testImplementation group: 'org.mockito', name: 'mockito-core', version:'1.10.19'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'


### PR DESCRIPTION
### Changes
We are updating the version of Guava to latest as fix for [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976).
We have verified the major version change shouldn't break the flow for us mentioned [here](https://github.com/google/guava/releases/tag/v32.0.0) 


### References
https://nvd.nist.gov/vuln/detail/CVE-2023-2976
https://github.com/google/guava/releases/tag/v32.0.0
https://github.com/google/guava/releases/tag/v32.1.1
