### PR TITLE
[SDK-4444] Use GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,27 @@
+name: auth0/jwks-rsa-java/build-and-test
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: ["master", "main"]
+
+jobs:
+  gradle:
+    runs-on:  ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+      - uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c
+        with:
+          arguments: assemble apiDiff check jacocoTestReport --continue --console=plain
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+        with:
+          flags: unittests
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Reports
+          path: lib/build/reports

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gradle"
+    directory: "lib"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Use GitHub Actions to build and test. A follow-up change will remove CircleCI.