### PR TITLE
fix: bumps guava patch to unblock android users

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.15.0'
-    implementation (group: 'com.google.guava', name: 'guava', version:'32.1.1-jre') {
+    implementation (group: 'com.google.guava', name: 'guava', version:'32.1.2-jre') {
         // needed due to https://github.com/google/guava/issues/6654
         exclude group: "org.mockito", module: "mockito-core"
     }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

This PR bumps the patch version of guava to unblock android users.

### References

Please include relevant links supporting this change such as a:

More context https://github.com/googleapis/google-cloud-java/issues/9715
A fast follow patch release of this lib would be appreciated so we can update it here.
https://github.com/microsoftgraph/msgraph-sdk-java-core/blob/1819351f46e6a7249fe2157405783fc483718f8c/gradle/dependencies.gradle#L16

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

(no local tests as I'm simply bumping a dependency, I expect any potential regression would be caught by CI)

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
