### PR TITLE
fix: bumps guava patch to unblock android users

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
 
 dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.15.0'
-    implementation (group: 'com.google.guava', name: 'guava', version:'32.1.1-jre') {
+    implementation (group: 'com.google.guava', name: 'guava', version:'32.1.2-jre') {
         // needed due to https://github.com/google/guava/issues/6654
         exclude group: "org.mockito", module: "mockito-core"
     }


### PR DESCRIPTION
This PR bumps the patch version of guava to unblock android users.

References
Please include relevant links supporting this change such as a:

More context https://github.com/googleapis/google-cloud-java/issues/9715
A fast follow patch release of this lib would be appreciated so we can update it here.
https://github.com/microsoftgraph/msgraph-sdk-java-core/blob/1819351f46e6a7249fe2157405783fc483718f8c/gradle/dependencies.gradle#L16