### PR TITLE
Chore: Bump guava dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ ext {
 
 dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.18.6'
-    implementation (group: 'com.google.guava', name: 'guava', version:'32.1.2-jre') {
+    implementation (group: 'com.google.guava', name: 'guava', version:'33.6.0-jre') {
         // needed due to https://github.com/google/guava/issues/6654
         exclude group: "org.mockito", module: "mockito-core"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ ext {
 }
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.18.6'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.21.2'
     implementation (group: 'com.google.guava', name: 'guava', version:'33.6.0-jre') {
         // needed due to https://github.com/google/guava/issues/6654
         exclude group: "org.mockito", module: "mockito-core"


### PR DESCRIPTION
### Changes

Bumped `com.google.guava` to `33.6.0-jre`

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds test coverage
- [ ] This change has been tested on the latest version of Java or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
