### PR TITLE
Chore: Add Automatic-Module-Name to JAR manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ compileJava {
     targetCompatibility '1.8'
 }
 
+jar {
+    manifest {
+        attributes 'Automatic-Module-Name': 'com.auth0.jwks'
+    }
+}
+
 import me.champeau.gradle.japicmp.JapicmpTask
 
 project.afterEvaluate {


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                               
  - Adds `Automatic-Module-Name: com.auth0.jwks` to the JAR manifest                                                                                                                                       
  - Provides a stable JPMS module name for downstream consumers without requiring a full `module-info.java`                                                                                                
                                                                                                                                                                                                           
  ## Context                                                                                                                                                                                               
This adds Java Module System support.                                                                                                                   
                                         
  We opted for `Automatic-Module-Name` over a full MRJAR approach because:
  - The library targets Java 8
  - There is only one package (`com.auth0.jwk`)
  - Internal classes are already package-private   